### PR TITLE
Directly use EventReader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ manage_clipboard = ["clipboard", "thread_local"]
 open_url = ["webbrowser"]
 
 [dependencies]
-bevy = { version = "0.4", default-features = false, features = ["render"] }
-bevy_winit = "0.4.0"
+bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = ["render"] }
+bevy_winit = { git = "https://github.com/bevyengine/bevy" }
 egui = "0.9.0"
 webbrowser = { version = "0.5.5", optional = true }
 winit = { version = "0.24.0", features = ["x11"], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ manage_clipboard = ["clipboard", "thread_local"]
 open_url = ["webbrowser"]
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = ["render"] }
-bevy_winit = { git = "https://github.com/bevyengine/bevy" }
+bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["render"] }
+bevy_winit = { git = "https://github.com/bevyengine/bevy", branch = "main" }
 egui = "0.9.0"
 webbrowser = { version = "0.5.5", optional = true }
 winit = { version = "0.24.0", features = ["x11"], default-features = false }

--- a/src/egui_node.rs
+++ b/src/egui_node.rs
@@ -3,7 +3,7 @@ use crate::{
     EGUI_TEXTURE_RESOURCE_BINDING_NAME, EGUI_TRANSFORM_RESOURCE_BINDING_NAME,
 };
 use bevy::{
-    app::{EventReader, Events},
+    app::{Events, ManualEventReader},
     asset::{AssetEvent, Assets, Handle},
     core::AsBytes,
     ecs::{Resources, World},
@@ -48,7 +48,6 @@ pub struct EguiNode {
     egui_texture_version: Option<u64>,
     texture_bind_group_descriptor: Option<BindGroupDescriptor>,
     texture_resources: HashMap<Handle<Texture>, TextureResource>,
-    event_reader: EventReader<AssetEvent<Texture>>,
 
     vertex_buffer: Option<BufferId>,
     index_buffer: Option<BufferId>,
@@ -133,7 +132,6 @@ impl EguiNode {
             egui_texture_version: None,
             texture_bind_group_descriptor: None,
             texture_resources: Default::default(),
-            event_reader: Default::default(),
             vertex_buffer: None,
             index_buffer: None,
             color_resolve_target_indices,
@@ -425,7 +423,8 @@ impl EguiNode {
         texture_assets: &mut Assets<Texture>,
     ) {
         let mut changed_assets: HashMap<Handle<Texture>, &Texture> = HashMap::new();
-        for event in self.event_reader.iter(asset_events) {
+        let mut asset_event_reader = ManualEventReader::<AssetEvent<Texture>>::default();
+        for event in asset_event_reader.iter(asset_events) {
             let handle = match event {
                 AssetEvent::Created { ref handle }
                 | AssetEvent::Modified { ref handle }

--- a/src/egui_node.rs
+++ b/src/egui_node.rs
@@ -15,8 +15,8 @@ use bevy::{
         },
         pipeline::{
             BindGroupDescriptor, IndexFormat, InputStepMode, PipelineCompiler, PipelineDescriptor,
-            PipelineLayout, PipelineSpecialization, VertexAttributeDescriptor,
-            VertexBufferDescriptor, VertexFormat,
+            PipelineLayout, PipelineSpecialization, VertexAttribute, VertexBufferLayout,
+            VertexFormat,
         },
         render_graph::{base::Msaa, Node, ResourceSlotInfo, ResourceSlots},
         renderer::{
@@ -235,7 +235,7 @@ impl Node for EguiNode {
             &mut |render_pass| {
                 render_pass.set_pipeline(self.pipeline_descriptor.as_ref().unwrap());
                 render_pass.set_vertex_buffer(0, self.vertex_buffer.unwrap(), 0);
-                render_pass.set_index_buffer(self.index_buffer.unwrap(), 0);
+                render_pass.set_index_buffer(self.index_buffer.unwrap(), 0, IndexFormat::Uint32);
                 render_pass.set_bind_group(
                     0,
                     self.transform_bind_group_descriptor.as_ref().unwrap().id,
@@ -342,19 +342,19 @@ impl EguiNode {
             let mut pipeline_compiler = resources.get_mut::<PipelineCompiler>().unwrap();
 
             let attributes = vec![
-                VertexAttributeDescriptor {
+                VertexAttribute {
                     name: Cow::from("Vertex_Position"),
                     offset: 0,
                     format: VertexFormat::Float2,
                     shader_location: 0,
                 },
-                VertexAttributeDescriptor {
+                VertexAttribute {
                     name: Cow::from("Vertex_Uv"),
                     offset: VertexFormat::Float2.get_size(),
                     format: VertexFormat::Float2,
                     shader_location: 1,
                 },
-                VertexAttributeDescriptor {
+                VertexAttribute {
                     name: Cow::from("Vertex_Color"),
                     offset: VertexFormat::Float2.get_size() + VertexFormat::Float2.get_size(),
                     format: VertexFormat::Float4,
@@ -367,7 +367,7 @@ impl EguiNode {
                 &mut shaders,
                 &EGUI_PIPELINE_HANDLE.typed(),
                 &PipelineSpecialization {
-                    vertex_buffer_descriptor: VertexBufferDescriptor {
+                    vertex_buffer_layout: VertexBufferLayout {
                         name: Cow::from("EguiVertex"),
                         stride: attributes
                             .iter()
@@ -375,7 +375,7 @@ impl EguiNode {
                         step_mode: InputStepMode::Vertex,
                         attributes,
                     },
-                    index_format: IndexFormat::Uint32,
+                    strip_index_format: Some(IndexFormat::Uint32),
                     sample_count: msaa.samples,
                     ..PipelineSpecialization::default()
                 },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,10 +65,10 @@ use bevy::{
     reflect::TypeUuid,
     render::{
         pipeline::{
-            BlendDescriptor, BlendFactor, BlendOperation, ColorStateDescriptor, ColorWrite,
-            CompareFunction, CullMode, DepthStencilStateDescriptor, FrontFace, IndexFormat,
-            PipelineDescriptor, RasterizationStateDescriptor, StencilStateDescriptor,
-            StencilStateFaceDescriptor,
+            BlendFactor, BlendOperation, BlendState, ColorTargetState, ColorWrite,
+            CompareFunction, CullMode, DepthBiasState, DepthStencilState, FrontFace,
+            IndexFormat, MultisampleState, PipelineDescriptor, PrimitiveState,
+            StencilFaceState, StencilState,
         },
         render_graph::{base, base::Msaa, RenderGraph, WindowSwapChainNode, WindowTextureNode},
         shader::{Shader, ShaderStage, ShaderStages},
@@ -401,41 +401,48 @@ impl Plugin for EguiPlugin {
 
 fn build_egui_pipeline(shaders: &mut Assets<Shader>, sample_count: u32) -> PipelineDescriptor {
     PipelineDescriptor {
-        rasterization_state: Some(RasterizationStateDescriptor {
+        primitive: PrimitiveState {
             front_face: FrontFace::Cw,
             cull_mode: CullMode::None,
-            depth_bias: 0,
-            depth_bias_slope_scale: 0.0,
-            depth_bias_clamp: 0.0,
-            clamp_depth: false,
-        }),
-        depth_stencil_state: Some(DepthStencilStateDescriptor {
+            strip_index_format: Some(IndexFormat::Uint32),
+            ..PrimitiveState::default()
+        },
+        depth_stencil: Some(DepthStencilState {
             format: TextureFormat::Depth32Float,
             depth_write_enabled: true,
             depth_compare: CompareFunction::LessEqual,
-            stencil: StencilStateDescriptor {
-                front: StencilStateFaceDescriptor::IGNORE,
-                back: StencilStateFaceDescriptor::IGNORE,
+            stencil: StencilState {
+                front: StencilFaceState::IGNORE,
+                back: StencilFaceState::IGNORE,
                 read_mask: 0,
                 write_mask: 0,
             },
+            bias: DepthBiasState {
+                constant: 0,
+                slope_scale: 0.0,
+                clamp: 0.0,
+            },
+            clamp_depth: false,
         }),
-        color_states: vec![ColorStateDescriptor {
+        color_target_states: vec![ColorTargetState {
             format: TextureFormat::default(),
-            color_blend: BlendDescriptor {
+            color_blend: BlendState {
                 src_factor: BlendFactor::One,
                 dst_factor: BlendFactor::OneMinusSrcAlpha,
                 operation: BlendOperation::Add,
             },
-            alpha_blend: BlendDescriptor {
+            alpha_blend: BlendState {
                 src_factor: BlendFactor::One,
                 dst_factor: BlendFactor::OneMinusSrcAlpha,
                 operation: BlendOperation::Add,
             },
             write_mask: ColorWrite::ALL,
         }],
-        index_format: IndexFormat::Uint32,
-        sample_count,
+        multisample: MultisampleState {
+            count: sample_count,
+            mask: !0,
+            alpha_to_coverage_enabled: false,
+        },
         ..PipelineDescriptor::new(ShaderStages {
             vertex: shaders.add(Shader::from_glsl(
                 ShaderStage::Vertex,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,10 +58,9 @@ mod transform_node;
 
 use crate::{egui_node::EguiNode, systems::*, transform_node::EguiTransformNode};
 use bevy::{
-    app::{stage as bevy_stage, AppBuilder, EventReader, Plugin},
+    app::{stage as bevy_stage, AppBuilder, Plugin},
     asset::{Assets, Handle, HandleUntyped},
     ecs::{IntoSystem, SystemStage},
-    input::mouse::MouseWheel,
     log,
     reflect::TypeUuid,
     render::{
@@ -76,7 +75,6 @@ use bevy::{
         stage as bevy_render_stage,
         texture::{Texture, TextureFormat},
     },
-    window::{CursorLeft, CursorMoved, ReceivedCharacter},
 };
 #[cfg(all(feature = "manage_clipboard", not(target_arch = "wasm32")))]
 use clipboard::{ClipboardContext, ClipboardProvider};
@@ -223,10 +221,6 @@ pub struct EguiContext {
     egui_textures: HashMap<egui::TextureId, Handle<Texture>>,
 
     mouse_position: Option<(f32, f32)>,
-    cursor_left: EventReader<CursorLeft>,
-    cursor_moved: EventReader<CursorMoved>,
-    mouse_wheel: EventReader<MouseWheel>,
-    received_character: EventReader<ReceivedCharacter>,
 }
 
 impl EguiContext {
@@ -235,10 +229,6 @@ impl EguiContext {
             ctx: Default::default(),
             egui_textures: Default::default(),
             mouse_position: Some((0.0, 0.0)),
-            cursor_left: Default::default(),
-            cursor_moved: Default::default(),
-            mouse_wheel: Default::default(),
-            received_character: Default::default(),
         }
     }
 

--- a/src/transform_node.rs
+++ b/src/transform_node.rs
@@ -5,7 +5,7 @@ use bevy::{
     render::{
         render_graph::{CommandQueue, Node, ResourceSlots, SystemNode},
         renderer::{
-            BufferId, BufferInfo, BufferUsage, RenderContext, RenderResourceBinding,
+            BufferId, BufferInfo, BufferMapMode, BufferUsage, RenderContext, RenderResourceBinding,
             RenderResourceBindings, RenderResourceContext,
         },
     },
@@ -83,7 +83,7 @@ fn transform_node_system(
     let transform_data_size = std::mem::size_of::<[[f32; 2]; 2]>();
 
     let staging_buffer = if let Some(staging_buffer) = state.staging_buffer {
-        render_resource_context.map_buffer(staging_buffer);
+        render_resource_context.map_buffer(staging_buffer, BufferMapMode::Write);
         staging_buffer
     } else {
         let buffer = render_resource_context.create_buffer(BufferInfo {


### PR DESCRIPTION
Use EventReader directly, which was made possible by https://github.com/bevyengine/bevy/pull/1244.

This should not be merged before the release of Bevy 0.5, as it needs at least commit https://github.com/bevyengine/bevy/commit/a880b5450829411b0248e47cc066915234371d86 to work.

One test is failing, but i am not sure if it has something to do with my changes. I tested this in one of my project and it works just fine.

```
running 2 tests
test src\lib.rs - EguiSettings::scale_factor (line 100) ... ok
test src\lib.rs - (line 23) ... FAILED

failures:

---- src\lib.rs - (line 23) stdout ----
Test executable failed (exit code 101).

stderr:
thread 'Compute Task Pool (2)' panicked at 'assertion failed: pixels_per_point > 0.0', C:\Users\...\.cargo\registry\src\github.com-1ecc6299db9ec823\epaint-0.8.0\src\text\font.rs:76:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'main' panicked at 'task has failed', C:\Users\...\.cargo\registry\src\github.com-1ecc6299db9ec823\async-task-4.0.3\src\task.rs:368:45



failures:
    src\lib.rs - (line 23)

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.15s
```