### PR TITLE
Fix texture copying

### DIFF
--- a/src/egui_node.rs
+++ b/src/egui_node.rs
@@ -614,9 +614,7 @@ impl EguiNode {
         texture: &Texture,
     ) {
         let width = texture.size.width as usize;
-        let aligned_width = render_context
-            .resources()
-            .get_aligned_texture_size(width);
+        let aligned_width = render_context.resources().get_aligned_texture_size(width);
         let format_size = texture.format.pixel_size();
         let mut aligned_data = vec![
             0;
@@ -631,8 +629,7 @@ impl EguiNode {
             .enumerate()
             .for_each(|(index, row)| {
                 let offset = index * aligned_width * format_size;
-                aligned_data[offset..(offset + width * format_size)]
-                    .copy_from_slice(row);
+                aligned_data[offset..(offset + width * format_size)].copy_from_slice(row);
             });
         let texture_buffer = render_context.resources().create_buffer_with_data(
             BufferInfo {

--- a/src/egui_node.rs
+++ b/src/egui_node.rs
@@ -613,17 +613,33 @@ impl EguiNode {
         texture_resource: &TextureResource,
         texture: &Texture,
     ) {
+        let width = texture.size.width as usize;
         let aligned_width = render_context
             .resources()
-            .get_aligned_texture_size(texture.size.width as usize);
+            .get_aligned_texture_size(width);
         let format_size = texture.format.pixel_size();
-
+        let mut aligned_data = vec![
+            0;
+            format_size
+                * aligned_width
+                * texture.size.height as usize
+                * texture.size.depth as usize
+        ];
+        texture
+            .data
+            .chunks_exact(format_size * width)
+            .enumerate()
+            .for_each(|(index, row)| {
+                let offset = index * aligned_width * format_size;
+                aligned_data[offset..(offset + width * format_size)]
+                    .copy_from_slice(row);
+            });
         let texture_buffer = render_context.resources().create_buffer_with_data(
             BufferInfo {
                 buffer_usage: BufferUsage::COPY_SRC,
                 ..Default::default()
             },
-            &texture.data,
+            &aligned_data,
         );
 
         render_context.copy_buffer_to_texture(


### PR DESCRIPTION
I was trying to load image textures other than the sample `icon.png`, and I kept getting this error:

```
thread 'main' panicked at 'copy would end up overruning the bounds of one of the buffers or textures', /Users/will/.cargo/registry/src/github.com-1ecc6299db9ec823/wgpu-0.6.2/src/backend/direct.rs:1355:35
stack backtrace:
   0: rust_begin_unwind
             at /rustc/80184183ba0a53aa4f491753de9502acd3d6920c/library/std/src/panicking.rs:493:5
   1: std::panicking::begin_panic_fmt
             at /rustc/80184183ba0a53aa4f491753de9502acd3d6920c/library/std/src/panicking.rs:435:5
   2: <core::result::Result<T,E> as wgpu::backend::direct::PrettyResult<T>>::unwrap_pretty::{{closure}}
             at /Users/will/.cargo/registry/src/github.com-1ecc6299db9ec823/wgpu-0.6.2/src/backend/direct.rs:1355:35
   3: core::result::Result<T,E>::unwrap_or_else
             at /Users/will/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/result.rs:821:23
   4: <core::result::Result<T,E> as wgpu::backend::direct::PrettyResult<T>>::unwrap_pretty
             at /Users/will/.cargo/registry/src/github.com-1ecc6299db9ec823/wgpu-0.6.2/src/backend/direct.rs:1355:9
   5: <wgpu::backend::direct::Context as wgpu::Context>::command_encoder_copy_buffer_to_texture
             at /Users/will/.cargo/registry/src/github.com-1ecc6299db9ec823/wgpu-0.6.2/src/backend/direct.rs:1152:9
   6: wgpu::CommandEncoder::copy_buffer_to_texture
             at /Users/will/.cargo/registry/src/github.com-1ecc6299db9ec823/wgpu-0.6.2/src/lib.rs:1847:9
   7: bevy_wgpu::renderer::wgpu_render_resource_context::WgpuRenderResourceContext::copy_buffer_to_texture
             at /Users/will/Code/bevy/crates/bevy_wgpu/src/renderer/wgpu_render_resource_context.rs:85:9
   8: <bevy_wgpu::renderer::wgpu_render_context::WgpuRenderContext as bevy_render::renderer::render_context::RenderContext>::copy_buffer_to_texture
             at /Users/will/Code/bevy/crates/bevy_wgpu/src/renderer/wgpu_render_context.rs:105:9
   9: bevy_egui::egui_node::EguiNode::copy_texture
             at /Users/will/Code/bevy_egui/src/egui_node.rs:631:9
  10: bevy_egui::egui_node::EguiNode::create_texture
             at /Users/will/Code/bevy_egui/src/egui_node.rs:589:9
  11: bevy_egui::egui_node::EguiNode::init_textures
             at /Users/will/Code/bevy_egui/src/egui_node.rs:514:13
  12: <bevy_egui::egui_node::EguiNode as bevy_render::render_graph::node::Node>::update
             at /Users/will/Code/bevy_egui/src/egui_node.rs:187:9
```

I copied the latest texture copying code over from [bevy](https://github.com/bevyengine/bevy/blob/master/crates/bevy_render/src/render_graph/nodes/texture_copy_node.rs#L36-L78) and it seemed to fix my problem.