### PR TITLE
Multiple windows support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 10-Apr-2021
+
+Huge thanks to @jakobhellermann and @Weasy666 for contributing to this release!
+
+### Added
+
+- Implement Egui 0.11.0 support ([#12](https://github.com/mvlabat/bevy_egui/pull/12) by @Weasy666 and @jakobhellermann).
+- Implement multiple windows support ([#14](https://github.com/mvlabat/bevy_egui/pull/14) by @jakobhellermann).
+
 ## [0.3.0] - 02-Mar-2021
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,21 +8,20 @@
 
 This crate provides a [Egui](https://github.com/emilk/egui) integration for the [Bevy](https://github.com/bevyengine/bevy) game engine.
 
+**Trying out:**
+
+An example WASM project is live at [mvlabat.github.io/bevy_egui_web_showcase](https://mvlabat.github.io/bevy_egui_web_showcase/index.html) [[source](https://github.com/mvlabat/bevy_egui_web_showcase)].
+
 **Features:**
 - Desktop and web ([bevy_webgl2](https://github.com/mrk-its/bevy_webgl2)) platforms support
 - Clipboard (web support is limited to the same window, see [rust-windowing/winit#1829](https://github.com/rust-windowing/winit/issues/1829))
 - Opening URLs
+- Multiple windows support (see [./examples/two_windows.rs](./examples/two_windows.rs))
 
 `bevy_egui` can be compiled with using only `bevy` and `egui` as dependencies: `manage_clipboard` and `open_url` features,
 that require additional crates, can be disabled.
 
 ![bevy_egui](bevy_egui.png)
-
-## Trying out
-
-An example WASM project is live at [mvlabat.github.io/bevy_egui_web_showcase](https://mvlabat.github.io/bevy_egui_web_showcase/index.html) [[source](https://github.com/mvlabat/bevy_egui_web_showcase)].
-
-**Note** that in order to use `bevy_egui`in WASM you need [bevy_webgl2](https://github.com/mrk-its/bevy_webgl2) of at least `0.5.0` version.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ fn main() {
 }
 
 fn ui_example(mut egui_context: ResMut<EguiContext>) {
-    let ctx = &mut egui_context.ctx;
-    egui::Window::new("Hello").show(ctx, |ui| {
+    egui::Window::new("Hello").show(egui_context.ctx(), |ui| {
         ui.label("world");
     });
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -9,9 +9,8 @@ fn main() {
         .run();
 }
 
-fn ui_example(mut egui_context: ResMut<EguiContext>) {
-    let ctx = &mut egui_context.ctx;
-    egui::Window::new("Hello").show(ctx, |ui| {
+fn ui_example(egui_context: Res<EguiContext>) {
+    egui::Window::new("Hello").show(egui_context.ctx(), |ui| {
         ui.label("world");
     });
 }

--- a/examples/two_windows.rs
+++ b/examples/two_windows.rs
@@ -1,0 +1,264 @@
+use bevy::{
+    prelude::*,
+    render::{
+        camera::{ActiveCameras, Camera},
+        pass::*,
+        render_graph::{
+            base::MainPass, CameraNode, PassNode, RenderGraph, WindowSwapChainNode,
+            WindowTextureNode,
+        },
+        texture::{Extent3d, TextureDescriptor, TextureDimension, TextureFormat, TextureUsage},
+    },
+    window::{CreateWindow, WindowDescriptor, WindowId},
+};
+use bevy_egui::{egui, EguiContext, EguiPlugin, EguiSettings};
+
+/// This example creates a second window and draws a mesh from two different cameras.
+fn main() {
+    App::build()
+        .insert_resource(Msaa { samples: 4 })
+        .add_state(AppState::CreateWindow)
+        .add_plugins(DefaultPlugins)
+        .insert_resource(EguiSettings {
+            window: None,
+            ..Default::default()
+        })
+        .add_plugin(EguiPlugin)
+        .add_system_set(
+            SystemSet::on_update(AppState::CreateWindow).with_system(setup_window.system()),
+        )
+        .add_system_set(SystemSet::on_update(AppState::Setup).with_system(setup.system()))
+        .add_system_set(SystemSet::on_update(AppState::Done).with_system(ui_example.system()))
+        .run();
+}
+
+// NOTE: this "state based" approach to multiple windows is a short term workaround.
+// Future Bevy releases shouldn't require such a strict order of operations.
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+enum AppState {
+    CreateWindow,
+    Setup,
+    Done,
+}
+
+fn setup_window(
+    mut app_state: ResMut<State<AppState>>,
+    mut create_window_events: EventWriter<CreateWindow>,
+) {
+    let window_id = WindowId::new();
+
+    // sends out a "CreateWindow" event, which will be received by the windowing backend
+    create_window_events.send(CreateWindow {
+        id: window_id,
+        descriptor: WindowDescriptor {
+            width: 800.,
+            height: 600.,
+            vsync: false,
+            title: "second window".to_string(),
+            ..Default::default()
+        },
+    });
+
+    app_state.set(AppState::Setup).unwrap();
+}
+
+mod second_window {
+    pub const SWAP_CHAIN: &str = "second_window_swap_chain";
+    pub const DEPTH_TEXTURE: &str = "second_window_depth_texture";
+    pub const CAMERA_NODE: &str = "secondary_camera";
+    pub const CAMERA_NAME: &str = "Secondary";
+    pub const SAMPLED_COLOR_ATTACHMENT: &str = "second_multi_sampled_color_attachment";
+    pub const PASS: &str = "second_window_pass";
+}
+
+fn setup_pipeline(
+    render_graph: &mut RenderGraph,
+    active_cameras: &mut ActiveCameras,
+    msaa: &Msaa,
+    window_id: WindowId,
+) {
+    // here we setup our render graph to draw our second camera to the new window's swap chain
+
+    // add a swapchain node for our new window
+    render_graph.add_node(
+        second_window::SWAP_CHAIN,
+        WindowSwapChainNode::new(window_id),
+    );
+
+    // add a new depth texture node for our new window
+    render_graph.add_node(
+        second_window::DEPTH_TEXTURE,
+        WindowTextureNode::new(
+            window_id,
+            TextureDescriptor {
+                format: TextureFormat::Depth32Float,
+                usage: TextureUsage::OUTPUT_ATTACHMENT,
+                sample_count: msaa.samples,
+                ..Default::default()
+            },
+        ),
+    );
+
+    // add a new camera node for our new window
+    render_graph.add_system_node(
+        second_window::CAMERA_NODE,
+        CameraNode::new(second_window::CAMERA_NAME),
+    );
+
+    // add a new render pass for our new window / camera
+    let mut second_window_pass = PassNode::<&MainPass>::new(PassDescriptor {
+        color_attachments: vec![msaa.color_attachment_descriptor(
+            TextureAttachment::Input("color_attachment".to_string()),
+            TextureAttachment::Input("color_resolve_target".to_string()),
+            Operations {
+                load: LoadOp::Clear(Color::rgb(0.5, 0.5, 0.8)),
+                store: true,
+            },
+        )],
+        depth_stencil_attachment: Some(RenderPassDepthStencilAttachmentDescriptor {
+            attachment: TextureAttachment::Input("depth".to_string()),
+            depth_ops: Some(Operations {
+                load: LoadOp::Clear(1.0),
+                store: true,
+            }),
+            stencil_ops: None,
+        }),
+        sample_count: msaa.samples,
+    });
+
+    second_window_pass.add_camera(second_window::CAMERA_NAME);
+    active_cameras.add(second_window::CAMERA_NAME);
+
+    render_graph.add_node(second_window::PASS, second_window_pass);
+
+    render_graph
+        .add_slot_edge(
+            second_window::SWAP_CHAIN,
+            WindowSwapChainNode::OUT_TEXTURE,
+            second_window::PASS,
+            if msaa.samples > 1 {
+                "color_resolve_target"
+            } else {
+                "color_attachment"
+            },
+        )
+        .unwrap();
+
+    render_graph
+        .add_slot_edge(
+            second_window::DEPTH_TEXTURE,
+            WindowTextureNode::OUT_TEXTURE,
+            second_window::PASS,
+            "depth",
+        )
+        .unwrap();
+
+    render_graph
+        .add_node_edge(second_window::CAMERA_NODE, second_window::PASS)
+        .unwrap();
+
+    if msaa.samples > 1 {
+        render_graph.add_node(
+            second_window::SAMPLED_COLOR_ATTACHMENT,
+            WindowTextureNode::new(
+                window_id,
+                TextureDescriptor {
+                    size: Extent3d {
+                        depth: 1,
+                        width: 1,
+                        height: 1,
+                    },
+                    mip_level_count: 1,
+                    sample_count: msaa.samples,
+                    dimension: TextureDimension::D2,
+                    format: TextureFormat::default(),
+                    usage: TextureUsage::OUTPUT_ATTACHMENT,
+                },
+            ),
+        );
+
+        render_graph
+            .add_slot_edge(
+                second_window::SAMPLED_COLOR_ATTACHMENT,
+                WindowSwapChainNode::OUT_TEXTURE,
+                second_window::PASS,
+                "color_attachment",
+            )
+            .unwrap();
+    }
+
+    bevy_egui::setup_pipeline(
+        render_graph,
+        msaa,
+        bevy_egui::RenderGraphConfig {
+            egui_pass: "egui_pass",
+            main_pass: second_window::PASS,
+            swap_chain_node: second_window::SWAP_CHAIN,
+            depth_texture: second_window::DEPTH_TEXTURE,
+            sampled_color_attachment: second_window::SAMPLED_COLOR_ATTACHMENT,
+            transform_node: "egui_transform",
+        },
+    );
+}
+
+fn setup(
+    mut commands: Commands,
+    mut app_state: ResMut<State<AppState>>,
+    windows: Res<Windows>,
+    mut active_cameras: ResMut<ActiveCameras>,
+    mut render_graph: ResMut<RenderGraph>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut egui_settings: ResMut<EguiSettings>,
+    msaa: Res<Msaa>,
+) {
+    // get the non-default window id
+    let window_id = match windows
+        .iter()
+        .find(|w| w.id() != WindowId::default())
+        .map(|w| w.id())
+    {
+        Some(x) => x,
+        None => return,
+    };
+
+    egui_settings.window = Some(window_id);
+
+    setup_pipeline(&mut render_graph, &mut active_cameras, &msaa, window_id);
+
+    // SETUP SCENE
+
+    // add entities to the world
+    commands.spawn_bundle(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        ..Default::default()
+    });
+    // light
+    commands.spawn_bundle(LightBundle {
+        transform: Transform::from_xyz(4.0, 5.0, 4.0),
+        ..Default::default()
+    });
+    // main camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(0.0, 0.0, 6.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
+    // second window camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        camera: Camera {
+            name: Some("Secondary".to_string()),
+            window: window_id,
+            ..Default::default()
+        },
+        transform: Transform::from_xyz(6.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
+
+    app_state.set(AppState::Done).unwrap();
+}
+
+fn ui_example(mut egui_context: ResMut<EguiContext>) {
+    let ctx = &mut egui_context.ctx;
+    egui::Window::new("Hello").show(ctx, |ui| {
+        ui.label("world");
+    });
+}

--- a/examples/two_windows.rs
+++ b/examples/two_windows.rs
@@ -271,17 +271,19 @@ struct UiState {
 }
 
 fn ui_first_window(egui_context: Res<EguiContext>, mut ui_state: Local<UiState>) {
-    egui::Window::new("First Window").show(egui_context.ctx(), |ui| {
-        ui.horizontal(|ui| {
-            ui.label("Write something: ");
-            ui.text_edit_singleline(&mut ui_state.label);
-        });
+    egui::Window::new("First Window")
+        .scroll(true)
+        .show(egui_context.ctx(), |ui| {
+            ui.horizontal(|ui| {
+                ui.label("Write something: ");
+                ui.text_edit_singleline(&mut ui_state.label);
+            });
 
-        ui.add(egui::widgets::Image::new(
-            egui::TextureId::User(BEVY_TEXTURE_ID),
-            [256.0, 256.0],
-        ));
-    });
+            ui.add(egui::widgets::Image::new(
+                egui::TextureId::User(BEVY_TEXTURE_ID),
+                [256.0, 256.0],
+            ));
+        });
 }
 
 fn ui_second_window(
@@ -289,15 +291,18 @@ fn ui_second_window(
     second_window: Res<SecondWindow>,
     mut ui_state: Local<UiState>,
 ) {
-    egui::Window::new("Second Window").show(egui_context.ctx_for_window(second_window.id), |ui| {
-        ui.horizontal(|ui| {
-            ui.label("Write something else: ");
-            ui.text_edit_singleline(&mut ui_state.label);
-        });
+    egui::Window::new("Second Window").scroll(true).show(
+        egui_context.ctx_for_window(second_window.id),
+        |ui| {
+            ui.horizontal(|ui| {
+                ui.label("Write something else: ");
+                ui.text_edit_singleline(&mut ui_state.label);
+            });
 
-        ui.add(egui::widgets::Image::new(
-            egui::TextureId::User(BEVY_TEXTURE_ID),
-            [256.0, 256.0],
-        ));
-    });
+            ui.add(egui::widgets::Image::new(
+                egui::TextureId::User(BEVY_TEXTURE_ID),
+                [256.0, 256.0],
+            ));
+        },
+    );
 }

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -30,7 +30,7 @@ fn load_assets(mut egui_context: ResMut<EguiContext>, assets: Res<AssetServer>) 
 }
 
 fn update_ui_scale_factor(mut egui_settings: ResMut<EguiSettings>, windows: Res<Windows>) {
-    if let Some(window) = windows.get(egui_settings.window) {
+    if let Some(window) = windows.get_primary() {
         egui_settings.scale_factor = 1.0 / window.scale_factor();
     }
 }
@@ -40,13 +40,11 @@ fn ui_example(
     mut ui_state: ResMut<UiState>,
     assets: Res<AssetServer>,
 ) {
-    let ctx = &mut egui_ctx.ctx;
-
     let mut load = false;
     let mut remove = false;
     let mut invert = false;
 
-    egui::SidePanel::left("side_panel", 200.0).show(ctx, |ui| {
+    egui::SidePanel::left("side_panel", 200.0).show(egui_ctx.ctx(), |ui| {
         ui.heading("Side Panel");
 
         ui.horizontal(|ui| {
@@ -76,7 +74,7 @@ fn ui_example(
         });
     });
 
-    egui::TopPanel::top("top_panel").show(ctx, |ui| {
+    egui::TopPanel::top("top_panel").show(egui_ctx.ctx(), |ui| {
         // The top panel is often a good place for a menu bar:
         egui::menu::bar(ui, |ui| {
             egui::menu::menu(ui, "File", |ui| {
@@ -87,7 +85,7 @@ fn ui_example(
         });
     });
 
-    egui::CentralPanel::default().show(ctx, |ui| {
+    egui::CentralPanel::default().show(egui_ctx.ctx(), |ui| {
         ui.heading("Egui Template");
         ui.hyperlink("https://github.com/emilk/egui_template");
         ui.add(egui::github_link_file_line!(
@@ -109,12 +107,14 @@ fn ui_example(
         });
     });
 
-    egui::Window::new("Window").scroll(true).show(ctx, |ui| {
-        ui.label("Windows can be moved by dragging them.");
-        ui.label("They are automatically sized based on contents.");
-        ui.label("You can turn on resizing and scrolling if you like.");
-        ui.label("You would normally chose either panels OR windows.");
-    });
+    egui::Window::new("Window")
+        .scroll(true)
+        .show(egui_ctx.ctx(), |ui| {
+            ui.label("Windows can be moved by dragging them.");
+            ui.label("They are automatically sized based on contents.");
+            ui.label("You can turn on resizing and scrolling if you like.");
+            ui.label("You would normally chose either panels OR windows.");
+        });
 
     if invert {
         ui_state.inverted = !ui_state.inverted;

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -30,7 +30,7 @@ fn load_assets(mut egui_context: ResMut<EguiContext>, assets: Res<AssetServer>) 
 }
 
 fn update_ui_scale_factor(mut egui_settings: ResMut<EguiSettings>, windows: Res<Windows>) {
-    if let Some(window) = windows.get_primary() {
+    if let Some(window) = windows.get(egui_settings.window) {
         egui_settings.scale_factor = 1.0 / window.scale_factor();
     }
 }

--- a/src/egui_node.rs
+++ b/src/egui_node.rs
@@ -27,14 +27,15 @@ use bevy::{
         shader::Shader,
         texture::{Extent3d, Texture, TextureDescriptor, TextureDimension, TextureFormat},
     },
+    utils::HashMap,
+    window::WindowId,
 };
 use egui::paint::ClippedShape;
-use std::{
-    borrow::Cow,
-    collections::{HashMap, HashSet},
-};
+use std::{borrow::Cow, collections::HashSet};
 
 pub struct EguiNode {
+    window_id: WindowId,
+
     pass_descriptor: PassDescriptor,
     pipeline_descriptor: Option<Handle<PipelineDescriptor>>,
     inputs: Vec<ResourceSlotInfo>,
@@ -67,7 +68,7 @@ pub struct TextureResource {
 }
 
 impl EguiNode {
-    pub fn new(msaa: &Msaa) -> Self {
+    pub fn new(msaa: &Msaa, window: WindowId) -> Self {
         let color_attachments = vec![msaa.color_attachment_descriptor(
             TextureAttachment::Input("color_attachment".to_string()),
             TextureAttachment::Input("color_resolve_target".to_string()),
@@ -121,6 +122,7 @@ impl EguiNode {
         }
 
         Self {
+            window_id: window,
             pass_descriptor: PassDescriptor {
                 color_attachments,
                 depth_stencil_attachment: Some(depth_stencil_attachment),
@@ -184,7 +186,10 @@ impl Node for EguiNode {
             &mut texture_assets,
         );
 
-        let mut egui_shapes = world.get_resource_mut::<EguiShapes>().unwrap();
+        let mut egui_shapes = world
+            .get_resource_mut::<HashMap<WindowId, EguiShapes>>()
+            .unwrap();
+        let egui_shapes = egui_shapes.get_mut(&self.window_id).unwrap();
         self.shapes = std::mem::take(&mut egui_shapes.shapes);
     }
 
@@ -199,10 +204,12 @@ impl Node for EguiNode {
 
         self.process_attachments(input, world);
 
-        let window_size = world.get_resource::<WindowSize>().unwrap();
+        let window_size = &world
+            .get_resource::<HashMap<WindowId, WindowSize>>()
+            .unwrap()[&self.window_id];
         let egui_settings = world.get_resource::<EguiSettings>().unwrap();
 
-        if window_size.physical_height == 0.0 {
+        if window_size.physical_width == 0.0 || window_size.physical_height == 0.0 {
             return;
         }
 
@@ -213,7 +220,7 @@ impl Node for EguiNode {
         let egui_context = world.get_resource::<EguiContext>().unwrap();
 
         let shapes = std::mem::take(&mut self.shapes);
-        let egui_paint_jobs = egui_context.ctx.tessellate(shapes);
+        let egui_paint_jobs = egui_context.ctx().tessellate(shapes);
 
         let mut vertex_buffer = Vec::<u8>::new();
         let mut index_buffer = Vec::new();
@@ -455,7 +462,7 @@ impl EguiNode {
         asset_events: &Events<AssetEvent<Texture>>,
         texture_assets: &mut Assets<Texture>,
     ) {
-        let mut changed_assets: HashMap<Handle<Texture>, &Texture> = HashMap::new();
+        let mut changed_assets: HashMap<Handle<Texture>, &Texture> = HashMap::default();
         let mut asset_event_reader = ManualEventReader::<AssetEvent<Texture>>::default();
         for event in asset_event_reader.iter(asset_events) {
             let handle = match event {
@@ -494,7 +501,7 @@ impl EguiNode {
             self.update_texture(render_resource_context, texture, texture_handle);
         }
 
-        let egui_texture = egui_context.ctx.texture();
+        let egui_texture = egui_context.ctx_for_window(self.window_id).texture();
         if self.egui_texture_version != Some(egui_texture.version) {
             self.egui_texture_version = Some(egui_texture.version);
             if let Some(egui_texture_handle) = self.egui_texture.clone() {
@@ -532,7 +539,7 @@ impl EguiNode {
         texture_assets: &mut Assets<Texture>,
     ) {
         if self.egui_texture.is_none() {
-            let texture = egui_context.ctx.texture();
+            let texture = egui_context.ctx_for_window(self.window_id).texture();
             self.egui_texture = Some(texture_assets.add(as_bevy_texture(&texture)));
             self.egui_texture_version = Some(texture.version);
 

--- a/src/egui_node.rs
+++ b/src/egui_node.rs
@@ -6,8 +6,8 @@ use bevy::{
     app::{Events, ManualEventReader},
     asset::{AssetEvent, Assets, Handle},
     core::AsBytes,
+    ecs::world::World,
     log,
-    prelude::World,
     render::{
         pass::{
             ClearColor, LoadOp, Operations, PassDescriptor,

--- a/src/egui_node.rs
+++ b/src/egui_node.rs
@@ -202,6 +202,10 @@ impl Node for EguiNode {
         let window_size = world.get_resource::<WindowSize>().unwrap();
         let egui_settings = world.get_resource::<EguiSettings>().unwrap();
 
+        if window_size.physical_height == 0.0 {
+            return;
+        }
+
         let render_resource_bindings = world.get_resource::<RenderResourceBindings>().unwrap();
 
         self.init_transform_bind_group(render_context, &render_resource_bindings);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,9 +60,12 @@ use crate::{egui_node::EguiNode, systems::*, transform_node::EguiTransformNode};
 use bevy::{
     app::{AppBuilder, CoreStage, Plugin},
     asset::{Assets, Handle, HandleUntyped},
+    ecs::{
+        schedule::{ParallelSystemDescriptorCoercion, StageLabel, SystemLabel, SystemStage},
+        system::IntoSystem,
+    },
     input::InputSystem,
     log,
-    prelude::{IntoSystem, ParallelSystemDescriptorCoercion, StageLabel, SystemLabel, SystemStage},
     reflect::TypeUuid,
     render::{
         pipeline::{

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -11,7 +11,9 @@ use bevy::{
         Input,
     },
     utils::HashMap,
-    window::{CursorLeft, CursorMoved, ReceivedCharacter, WindowFocused, WindowId, Windows},
+    window::{
+        CursorLeft, CursorMoved, ReceivedCharacter, WindowCreated, WindowFocused, WindowId, Windows,
+    },
     winit::WinitWindows,
 };
 
@@ -21,7 +23,8 @@ pub struct InputEvents<'a> {
     ev_cursor: EventReader<'a, CursorMoved>,
     ev_mouse_wheel: EventReader<'a, MouseWheel>,
     ev_received_character: EventReader<'a, ReceivedCharacter>,
-    ev_window_focus: EventReader<'a, WindowFocused>,
+    ev_window_focused: EventReader<'a, WindowFocused>,
+    ev_window_created: EventReader<'a, WindowCreated>,
 }
 
 #[derive(SystemParam)]
@@ -48,10 +51,15 @@ pub fn process_input(
     egui_settings: ResMut<EguiSettings>,
     time: Res<Time>,
 ) {
-    for focus_event in input_events.ev_window_focus.iter().rev() {
-        if focus_event.focused {
-            *window_resources.focused_window = focus_event.id;
-            break;
+    // This is a workaround for Windows. For some reason, `WindowFocused` event isn't fired.
+    // when a window is created.
+    for event in input_events.ev_window_created.iter().rev() {
+        *window_resources.focused_window = event.id;
+    }
+
+    for event in input_events.ev_window_focused.iter().rev() {
+        if event.focused {
+            *window_resources.focused_window = event.id;
         }
     }
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -273,17 +273,21 @@ pub fn process_output(
         }
 
         if let Some(winit_window) = winit_windows.get_window(id) {
-            if let Some(icon) = egui_to_winit_cursor_icon(output.cursor_icon) {
-                winit_window.set_cursor_icon(icon);
-            }
-        } else {
-            log::error!("No winit window found for the primary window");
+            winit_window.set_cursor_icon(
+                egui_to_winit_cursor_icon(output.cursor_icon)
+                    .unwrap_or(winit::window::CursorIcon::Default),
+            );
         }
 
+        // TODO: see if we can support `new_tab`.
         #[cfg(feature = "open_url")]
-        if let Some(url) = output.open_url {
-            if let Err(err) = webbrowser::open(&url.url) {
-                log::error!("Failed to open '{}': {:?}", &url.url, err);
+        if let Some(egui::output::OpenUrl {
+            url,
+            new_tab: _new_tab,
+        }) = output.open_url
+        {
+            if let Err(err) = webbrowser::open(&url) {
+                log::error!("Failed to open '{}': {:?}", url, err);
             }
         }
     }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,15 +1,15 @@
 use crate::{EguiContext, EguiInput, EguiOutput, EguiSettings, EguiShapes, WindowSize};
+#[cfg(feature = "open_url")]
+use bevy::log;
 use bevy::{
     app::EventReader,
     core::Time,
-    ecs::system::SystemParam,
+    ecs::system::{Local, Res, ResMut, SystemParam},
     input::{
         keyboard::KeyCode,
         mouse::{MouseButton, MouseScrollUnit, MouseWheel},
         Input,
     },
-    log,
-    prelude::{Local, Res, ResMut},
     utils::HashMap,
     window::{CursorLeft, CursorMoved, ReceivedCharacter, WindowFocused, WindowId, Windows},
     winit::WinitWindows,

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -203,6 +203,12 @@ pub fn process_input(
         }
     }
 
+    for egui_input in egui_input.values_mut() {
+        egui_input.raw_input.predicted_dt = time.delta_seconds();
+    }
+
+    let focused_input = egui_input.get_mut(&*focused_window).unwrap();
+
     #[cfg(feature = "manage_clipboard")]
     {
         let mut copy = false;
@@ -219,24 +225,21 @@ pub fn process_input(
                 paste = Some(contents);
             }
         }
-        for egui_input in egui_input.values_mut() {
-            if copy {
-                egui_input.raw_input.events.push(egui::Event::Copy);
-            }
-            if cut {
-                egui_input.raw_input.events.push(egui::Event::Cut);
-            }
-            if let Some(content) = paste.clone() {
-                egui_input.raw_input.events.push(egui::Event::Text(content))
-            }
+
+        if copy {
+            focused_input.raw_input.events.push(egui::Event::Copy);
+        }
+        if cut {
+            focused_input.raw_input.events.push(egui::Event::Cut);
+        }
+        if let Some(content) = paste {
+            focused_input
+                .raw_input
+                .events
+                .push(egui::Event::Text(content))
         }
     };
 
-    for egui_input in egui_input.values_mut() {
-        egui_input.raw_input.predicted_dt = time.delta_seconds();
-    }
-
-    let focused_input = egui_input.get_mut(&*focused_window).unwrap();
     focused_input.raw_input.modifiers = modifiers;
 }
 

--- a/src/transform_node.rs
+++ b/src/transform_node.rs
@@ -10,16 +10,20 @@ use bevy::{
             RenderResourceBindings, RenderResourceContext,
         },
     },
+    utils::HashMap,
+    window::WindowId,
 };
 
 #[derive(Debug)]
 pub struct EguiTransformNode {
+    window_id: WindowId,
     command_queue: CommandQueue,
 }
 
 impl EguiTransformNode {
-    pub fn new() -> Self {
+    pub fn new(window_id: WindowId) -> Self {
         EguiTransformNode {
+            window_id,
             command_queue: Default::default(),
         }
     }
@@ -41,6 +45,7 @@ impl SystemNode for EguiTransformNode {
     fn get_system(&self) -> Box<dyn System<In = (), Out = ()>> {
         let system = transform_node_system.system().config(|c| {
             c.0 = Some(TransformNodeState {
+                window_id: self.window_id,
                 command_queue: self.command_queue.clone(),
                 transform_buffer: None,
                 staging_buffer: None,
@@ -54,6 +59,7 @@ impl SystemNode for EguiTransformNode {
 
 #[derive(Default)]
 pub struct TransformNodeState {
+    window_id: WindowId,
     command_queue: CommandQueue,
     transform_buffer: Option<BufferId>,
     staging_buffer: Option<BufferId>,
@@ -64,10 +70,12 @@ pub struct TransformNodeState {
 fn transform_node_system(
     mut state: Local<TransformNodeState>,
     render_resource_context: Res<Box<dyn RenderResourceContext>>,
-    window_size: Res<WindowSize>,
+    window_size: Res<HashMap<WindowId, WindowSize>>,
     egui_settings: Res<EguiSettings>,
     mut render_resource_bindings: ResMut<RenderResourceBindings>,
 ) {
+    let window_size = &window_size[&state.window_id];
+
     #[allow(clippy::float_cmp)]
     if state.prev_window_size == *window_size
         && state.prev_scale_factor == egui_settings.scale_factor

--- a/src/transform_node.rs
+++ b/src/transform_node.rs
@@ -1,8 +1,10 @@
 use crate::{EguiSettings, WindowSize, EGUI_TRANSFORM_RESOURCE_BINDING_NAME};
 use bevy::{
     core::AsBytes,
-    ecs::world::World,
-    prelude::{IntoSystem, Local, Res, ResMut, System},
+    ecs::{
+        system::{IntoSystem, Local, Res, ResMut, System},
+        world::World,
+    },
     render::{
         render_graph::{CommandQueue, Node, ResourceSlots, SystemNode},
         renderer::{


### PR DESCRIPTION
Based on #13 

Issues to fix:
- [x] When a new window is spawned, it acquires the focus, at least on Windows (TODO: test other platforms), but the active context is still the default window. That results in events coming from the second window being consumed by the default context.
- [x] Clipboard can paste into several fields at the same time if they are all active in different windows.