### PR TITLE
Do not attempt to render widgets with no height or width.

### DIFF
--- a/src/egui_node.rs
+++ b/src/egui_node.rs
@@ -311,7 +311,7 @@ impl Node for EguiNode {
 
                     let scale_factor = window_size.scale_factor * egui_settings.scale_factor as f32;
 
-                    let (x, y, w, mut h) = (
+                    let (x, y, w, h) = (
                         (draw_command.clipping_zone.min.x * scale_factor) as u32,
                         (draw_command.clipping_zone.min.y * scale_factor) as u32,
                         (draw_command.clipping_zone.width() * scale_factor) as u32,

--- a/src/egui_node.rs
+++ b/src/egui_node.rs
@@ -315,13 +315,11 @@ impl Node for EguiNode {
                         (draw_command.clipping_zone.min.x * scale_factor) as u32,
                         (draw_command.clipping_zone.min.y * scale_factor) as u32,
                         (draw_command.clipping_zone.width() * scale_factor) as u32,
-                        (draw_command.clipping_zone.height() * scale_factor) as u32
+                        (draw_command.clipping_zone.height() * scale_factor) as u32,
                     );
 
                     if h != 0 && w != 0 {
-                        render_pass.set_scissor_rect(
-                            x, y, w, h,
-                        );
+                        render_pass.set_scissor_rect(x, y, w, h);
                         render_pass.draw_indexed(
                             vertex_offset..(vertex_offset + draw_command.vertices_count as u32),
                             0,

--- a/src/egui_node.rs
+++ b/src/egui_node.rs
@@ -310,18 +310,25 @@ impl Node for EguiNode {
                     );
 
                     let scale_factor = window_size.scale_factor * egui_settings.scale_factor as f32;
-                    render_pass.set_scissor_rect(
+
+                    let (x, y, w, mut h) = (
                         (draw_command.clipping_zone.min.x * scale_factor) as u32,
                         (draw_command.clipping_zone.min.y * scale_factor) as u32,
                         (draw_command.clipping_zone.width() * scale_factor) as u32,
-                        (draw_command.clipping_zone.height() * scale_factor) as u32,
+                        (draw_command.clipping_zone.height() * scale_factor) as u32
                     );
-                    render_pass.draw_indexed(
-                        vertex_offset..(vertex_offset + draw_command.vertices_count as u32),
-                        0,
-                        0..1,
-                    );
-                    vertex_offset += draw_command.vertices_count as u32;
+
+                    if h != 0 && w != 0 {
+                        render_pass.set_scissor_rect(
+                            x, y, w, h,
+                        );
+                        render_pass.draw_indexed(
+                            vertex_offset..(vertex_offset + draw_command.vertices_count as u32),
+                            0,
+                            0..1,
+                        );
+                        vertex_offset += draw_command.vertices_count as u32;
+                    }
                 }
             },
         );


### PR DESCRIPTION
This is a suggested fix for #15 

The idea is that if a widget would be either 0 in height or 0 in width (impossible to render), we should do just that, skip attempting to render it.