### PR TITLE
Clippy fixes

### DIFF
--- a/src/egui_node.rs
+++ b/src/egui_node.rs
@@ -215,7 +215,7 @@ impl Node for EguiNode {
 
         let render_resource_bindings = world.get_resource::<RenderResourceBindings>().unwrap();
 
-        self.init_transform_bind_group(render_context, &render_resource_bindings);
+        self.init_transform_bind_group(render_context, render_resource_bindings);
 
         let egui_context = world.get_resource::<EguiContext>().unwrap();
 
@@ -279,7 +279,7 @@ impl Node for EguiNode {
 
         render_context.begin_pass(
             &self.pass_descriptor,
-            &render_resource_bindings,
+            render_resource_bindings,
             &mut |render_pass| {
                 render_pass.set_pipeline(self.pipeline_descriptor.as_ref().unwrap());
                 render_pass.set_vertex_buffer(0, self.vertex_buffer.unwrap(), 0);
@@ -506,7 +506,7 @@ impl EguiNode {
                     egui_context.remove_texture(handle);
                     self.remove_texture(render_resource_context, handle);
                     // If an asset was modified and removed in the same update, ignore the modification.
-                    changed_assets.remove(&handle);
+                    changed_assets.remove(handle);
                 }
             }
         }
@@ -520,7 +520,7 @@ impl EguiNode {
             if let Some(egui_texture_handle) = self.egui_texture.clone() {
                 let texture_asset = texture_assets.get_mut(&egui_texture_handle).unwrap();
                 *texture_asset = as_bevy_texture(&egui_texture);
-                self.update_texture(render_resource_context, &texture_asset, egui_texture_handle);
+                self.update_texture(render_resource_context, texture_asset, egui_texture_handle);
             }
         }
     }
@@ -597,7 +597,7 @@ impl EguiNode {
         Self::copy_texture(
             &mut self.render_commands,
             render_resource_context,
-            &texture_resource,
+            texture_resource,
             texture_asset,
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,8 +246,7 @@ impl EguiContext {
     /// make sure to set up the render graph by calling [`setup_pipeline`].
     #[track_caller]
     pub fn ctx_for_window(&self, window: WindowId) -> &egui::CtxRef {
-        &self
-            .ctx
+        self.ctx
             .get(&window)
             .ok_or_else(|| format!("window with id {} not found", window))
             .unwrap()
@@ -433,7 +432,7 @@ impl Default for RenderGraphConfig {
 /// The pipeline for the primary window will already be set up by the [`EguiPlugin`],
 /// so you'll only need to manually call this if you want to use multiple windows.
 pub fn setup_pipeline(render_graph: &mut RenderGraph, msaa: &Msaa, config: RenderGraphConfig) {
-    render_graph.add_node(config.egui_pass, EguiNode::new(&msaa, config.window_id));
+    render_graph.add_node(config.egui_pass, EguiNode::new(msaa, config.window_id));
     render_graph
         .add_node_edge(config.main_pass, config.egui_pass)
         .unwrap();


### PR DESCRIPTION
The code had a few double references that `clippy` was complaining about. This PR gets rid of them, and thus gets rid of all `clippy` warnings.