### PR TITLE
run egui pass after `bevy_ui`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -460,6 +460,8 @@ pub fn setup_pipeline(
             config.egui_pass,
         )
         .unwrap();
+
+    let _ = render_graph.add_node_edge("ui_pass_driver", config.egui_pass);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
should fix #52 

@Hilku can you confirm by putting
```toml
[patch.crates-io]
bevy_egui = { git = "https://github.com/jakobhellermann/bevy_egui", branch = "after-ui-pass" }
```

in your `Cargo.toml`?