### PR TITLE
Remove megaui reference from lib.rs docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,6 @@
 //! ## See also
 //!
 //! - [`bevy-inspector-egui`](https://github.com/jakobhellermann/bevy-inspector-egui)
-//! - [`bevy_megaui`](https://github.com/mvlabat/bevy_megaui)
 
 pub use egui;
 


### PR DESCRIPTION
Found another link to `megaui`, which is deprecated and links back to `bevy_equi`, making it not useful.