### PR TITLE
Bevy 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,16 @@ multi_threaded = ["egui/multi_threaded"]
 open_url = ["webbrowser"]
 
 [dependencies]
-bevy = { version = "0.6", default-features = false, features = [
+bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
     "bevy_render",
     "bevy_winit",
-    "bevy_core_pipeline"
+    "bevy_core_pipeline",
 ] }
+# bevy = { version = "0.6", default-features = false, features = [
+#     "bevy_render",
+#     "bevy_winit",
+#     "bevy_core_pipeline"
+# ] }
 egui = { version = "0.17", features = ["convert_bytemuck"] }
 webbrowser = { version = "0.5.5", optional = true }
 winit = { version = "0.26.0", features = ["x11"], default-features = false }
@@ -35,6 +40,12 @@ arboard = { version = "2.0.1", optional = true }
 thread_local = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
-bevy = "0.6"
 once_cell = "1.9.0"
 version-sync = "0.9.2"
+
+
+bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
+    "x11",
+    "png",
+] }
+# bevy = { version = "0.6", default-features = false, features = ["x11", "png"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,8 @@ bevy = { version = "0.7", default-features = false, features = [
     "bevy_winit",
     "bevy_core_pipeline",
 ] }
-# bevy = { version = "0.6", default-features = false, features = [
-#     "bevy_render",
-#     "bevy_winit",
-#     "bevy_core_pipeline"
-# ] }
 egui = { version = "0.17", features = ["convert_bytemuck"] }
-webbrowser = { version = "0.5.5", optional = true }
+webbrowser = { version = "0.6.0", optional = true }
 winit = { version = "0.26.0", features = ["x11"], default-features = false }
 bytemuck = { version = "1.7.0", features = ["derive"] }
 wgpu = "0.12.0"

--- a/examples/side_panel.rs
+++ b/examples/side_panel.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::*;
+use bevy::{prelude::*, winit::WinitSettings};
 use bevy_egui::{egui, EguiContext, EguiPlugin};
 
 #[derive(Default)]
@@ -17,6 +17,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(EguiPlugin)
+        .insert_resource(WinitSettings::desktop_app())
         .init_resource::<OccupiedScreenSpace>()
         .add_startup_system(setup_system)
         .add_system(ui_example_system)

--- a/examples/side_panel.rs
+++ b/examples/side_panel.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, winit::WinitSettings};
+use bevy::{prelude::*, window::PresentMode, winit::WinitSettings};
 use bevy_egui::{egui, EguiContext, EguiPlugin};
 
 #[derive(Default)]
@@ -17,7 +17,12 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(EguiPlugin)
+        // Optimal power saving and present mode settings for desktop apps.
         .insert_resource(WinitSettings::desktop_app())
+        .insert_resource(WindowDescriptor {
+            present_mode: PresentMode::Mailbox,
+            ..Default::default()
+        })
         .init_resource::<OccupiedScreenSpace>()
         .add_startup_system(setup_system)
         .add_system(ui_example_system)

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,10 +1,14 @@
-use bevy::{prelude::*, winit::WinitSettings};
+use bevy::{prelude::*, window::PresentMode, winit::WinitSettings};
 use bevy_egui::{egui, EguiContext, EguiPlugin};
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .insert_resource(WinitSettings::desktop_app())
+        .insert_resource(WindowDescriptor {
+            present_mode: PresentMode::Mailbox,
+            ..Default::default()
+        })
         .add_plugin(EguiPlugin)
         .add_system(ui_example)
         .run();

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,9 +1,10 @@
-use bevy::prelude::*;
+use bevy::{prelude::*, winit::WinitSettings};
 use bevy_egui::{egui, EguiContext, EguiPlugin};
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
+        .insert_resource(WinitSettings::desktop_app())
         .add_plugin(EguiPlugin)
         .add_system(ui_example)
         .run();

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,15 +1,12 @@
-use bevy::{prelude::*, window::PresentMode, winit::WinitSettings};
+use bevy::prelude::*;
 use bevy_egui::{egui, EguiContext, EguiPlugin};
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .insert_resource(WinitSettings::desktop_app())
-        .insert_resource(WindowDescriptor {
-            present_mode: PresentMode::Mailbox,
-            ..Default::default()
-        })
         .add_plugin(EguiPlugin)
+        // Systems that create Egui widgets should be run during the `CoreStage::Update` stage,
+        // or after the `EguiSystem::BeginFrame` system (which belongs to the `CoreStage::PreUpdate` stage).
         .add_system(ui_example)
         .run();
 }

--- a/examples/two_windows.rs
+++ b/examples/two_windows.rs
@@ -16,7 +16,12 @@ struct Images {
 fn main() {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins)
+        // Optimal power saving and present mode settings for desktop apps.
         .insert_resource(WinitSettings::desktop_app())
+        .insert_resource(WindowDescriptor {
+            present_mode: PresentMode::Mailbox,
+            ..Default::default()
+        })
         .add_plugin(EguiPlugin)
         .init_resource::<SharedUiState>()
         .add_startup_system(load_assets)

--- a/examples/two_windows.rs
+++ b/examples/two_windows.rs
@@ -2,13 +2,14 @@ use bevy::{
     core_pipeline::{draw_3d_graph, node, AlphaMask3d, Opaque3d, Transparent3d},
     prelude::*,
     render::{
-        camera::{ActiveCameras, ExtractedCameraNames},
+        camera::{ActiveCameras, ExtractedCameraNames, RenderTarget},
         render_graph::{Node, NodeRunError, RenderGraph, RenderGraphContext, SlotValue},
         render_phase::RenderPhase,
         renderer::RenderContext,
         RenderApp, RenderStage,
     },
-    window::{CreateWindow, WindowId},
+    window::{CreateWindow, PresentMode, WindowId},
+    winit::WinitSettings,
 };
 use bevy_egui::{EguiContext, EguiPlugin};
 use once_cell::sync::Lazy;
@@ -22,6 +23,7 @@ struct Images {
 fn main() {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins)
+        .insert_resource(WinitSettings::desktop_app())
         .add_plugin(EguiPlugin)
         .init_resource::<SharedUiState>()
         .add_startup_system(load_assets)
@@ -75,7 +77,7 @@ fn create_new_window(
         descriptor: WindowDescriptor {
             width: 800.,
             height: 600.,
-            vsync: false,
+            present_mode: PresentMode::Mailbox,
             title: "Second window".to_string(),
             ..Default::default()
         },
@@ -83,7 +85,7 @@ fn create_new_window(
     // second window camera
     commands.spawn_bundle(PerspectiveCameraBundle {
         camera: Camera {
-            window: *SECOND_WINDOW_ID,
+            target: RenderTarget::Window(*SECOND_WINDOW_ID),
             name: Some(SECONDARY_CAMERA_NAME.into()),
             ..Default::default()
         },

--- a/examples/two_windows.rs
+++ b/examples/two_windows.rs
@@ -1,7 +1,8 @@
 use bevy::{
     prelude::*,
     render::{camera::RenderTarget, render_graph::RenderGraph, RenderApp},
-    window::{CreateWindow, WindowId},
+    window::{CreateWindow, PresentMode, WindowId},
+    winit::WinitSettings,
 };
 use bevy_egui::{EguiContext, EguiPlugin};
 use once_cell::sync::Lazy;

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -24,6 +24,7 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::rgb(0.0, 0.0, 0.0)))
         .insert_resource(Msaa { samples: 4 })
+        .insert_resource(WinitSettings::desktop_app())
         .init_resource::<UiState>()
         .add_plugins(DefaultPlugins)
         .insert_resource(WinitSettings::desktop_app())

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, winit::WinitSettings};
+use bevy::{prelude::*, window::PresentMode, winit::WinitSettings};
 use bevy_egui::{egui, EguiContext, EguiPlugin, EguiSettings};
 
 struct Images {
@@ -28,6 +28,10 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .insert_resource(WinitSettings::desktop_app())
         .add_plugin(EguiPlugin)
+        .insert_resource(WindowDescriptor {
+            present_mode: PresentMode::Mailbox,
+            ..Default::default()
+        })
         .add_startup_system(configure_visuals)
         .add_system(update_ui_scale_factor)
         .add_system(ui_example)

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::*;
+use bevy::{prelude::*, winit::WinitSettings};
 use bevy_egui::{egui, EguiContext, EguiPlugin, EguiSettings};
 
 struct Images {
@@ -26,6 +26,7 @@ fn main() {
         .insert_resource(Msaa { samples: 4 })
         .init_resource::<UiState>()
         .add_plugins(DefaultPlugins)
+        .insert_resource(WinitSettings::desktop_app())
         .add_plugin(EguiPlugin)
         .add_startup_system(configure_visuals)
         .add_system(update_ui_scale_factor)

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -24,15 +24,15 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::rgb(0.0, 0.0, 0.0)))
         .insert_resource(Msaa { samples: 4 })
+        // Optimal power saving and present mode settings for desktop apps.
         .insert_resource(WinitSettings::desktop_app())
-        .init_resource::<UiState>()
-        .add_plugins(DefaultPlugins)
-        .insert_resource(WinitSettings::desktop_app())
-        .add_plugin(EguiPlugin)
         .insert_resource(WindowDescriptor {
             present_mode: PresentMode::Mailbox,
             ..Default::default()
         })
+        .init_resource::<UiState>()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(EguiPlugin)
         .add_startup_system(configure_visuals)
         .add_system(update_ui_scale_factor)
         .add_system(ui_example)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -598,7 +598,7 @@ pub fn setup_pipeline(render_graph: &mut RenderGraph, config: RenderGraphConfig)
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bevy::{render::options::WgpuOptions, winit::WinitPlugin, DefaultPlugins};
+    use bevy::{render::settings::WgpuSettings, winit::WinitPlugin, DefaultPlugins};
 
     #[test]
     fn test_readme_deps() {
@@ -608,7 +608,7 @@ mod tests {
     #[test]
     fn test_headless_mode() {
         App::new()
-            .insert_resource(WgpuOptions {
+            .insert_resource(WgpuSettings {
                 backends: None,
                 ..Default::default()
             })

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -5,7 +5,10 @@ use crate::{EguiContext, EguiInput, EguiOutput, EguiRenderOutput, EguiSettings, 
 use bevy::log;
 use bevy::{
     core::Time,
-    ecs::system::{Local, Res, ResMut, SystemParam},
+    ecs::{
+        event::EventWriter,
+        system::{Local, Res, ResMut, SystemParam},
+    },
     input::{
         keyboard::{KeyCode, KeyboardInput},
         mouse::{MouseButton, MouseButtonInput, MouseScrollUnit, MouseWheel},


### PR DESCRIPTION
This is based on #78 for egui 0.17. If that is merged, I will rebase on main.

This branch will be used to track bevy/main until the next release.

The biggest upgrade is support for low power mode in bevy (https://github.com/bevyengine/bevy/pull/3974). I've added a few lines to `process_output` that checks if egui has reported `needs_repaint`, and sends a bevy `RequestRedraw` event. I've also updated the examples to use the new `WinitSettings::desktop_app()` mode for reactive rendering.

This means bevy_egui apps can now use zero resources unless the user is providing input, or there is an egui animation in progress!

![image](https://user-images.githubusercontent.com/2632925/157143985-d37713b7-cbb9-4d05-9045-542e68b15589.png)
