### PR TITLE
Add a funtion to get image id

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,7 +347,7 @@ impl EguiContext {
         id
     }
 
-    /// Returns associated Egui texture id
+    /// Returns associated Egui texture id.
     #[must_use]
     pub fn image_id(&self, image: &Handle<Image>) -> Option<egui::TextureId> {
         self.user_textures

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,6 +346,14 @@ impl EguiContext {
         log::debug!("Remove image (id: {:?}, handle: {:?})", id, image);
         id
     }
+
+    /// Returns associated Egui texture id
+    #[must_use]
+    pub fn image_id(&self, image: &Handle<Image>) -> Option<egui::TextureId> {
+        self.user_textures
+            .get(&image.id)
+            .map(|&id| egui::TextureId::User(id))
+    }
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
I added this function because `add_image` requires `mut` and sometimes it inconvenient because you can't use it inside `show`.