### PR TITLE
new_tab support on open_url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ bevy = { version = "0.7", default-features = false, features = [
     "bevy_core_pipeline",
 ] }
 egui = { version = "0.17", features = ["convert_bytemuck"] }
-webbrowser = { version = "0.6.0", optional = true }
+webbrowser = { version = "0.7.0", optional = true }
 winit = { version = "0.26.0", features = ["x11"], default-features = false }
 bytemuck = { version = "1.7.0", features = ["derive"] }
 wgpu = "0.12.0"

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -375,7 +375,6 @@ pub fn process_output(
             event.send(RequestRedraw)
         }
 
-        // TODO: see if we can support `new_tab`.
         #[cfg(feature = "open_url")]
         if let Some(egui::output::OpenUrl { url, new_tab }) = platform_output.open_url {
             let target = if new_tab { "_blank" } else { "_self" };

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -377,12 +377,13 @@ pub fn process_output(
 
         // TODO: see if we can support `new_tab`.
         #[cfg(feature = "open_url")]
-        if let Some(egui::output::OpenUrl {
-            url,
-            new_tab: _new_tab,
-        }) = platform_output.open_url
-        {
-            if let Err(err) = webbrowser::open(&url) {
+        if let Some(egui::output::OpenUrl { url, new_tab }) = platform_output.open_url {
+            let target = if new_tab { "_blank" } else { "_self" };
+            if let Err(err) = webbrowser::open_browser_with_options(
+                webbrowser::Browser::Default,
+                &url,
+                webbrowser::BrowserOptions::new().with_target_hint(target),
+            ) {
                 log::error!("Failed to open '{}': {:?}", url, err);
             }
         }


### PR DESCRIPTION
This fixes hyperlinks opening in a new tab whether modifiers are pressed or not.

There is still an issue: opening a hyperlink in a new tab, then coming back to the previous tab, will leave the modifier keys pressed even if they've been released in the meantime. But I believe this is an issue with bevy and not bevy_egui.