### PR TITLE
update to bevy 0.9 dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,18 +21,18 @@ open_url = ["webbrowser"]
 default_fonts = ["egui/default_fonts"]
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["bevy_render", "bevy_core_pipeline", "bevy_asset"] }
+bevy = { version = "0.9.0", default-features = false, features = ["bevy_render", "bevy_core_pipeline", "bevy_asset"] }
 egui = { version = "0.19.0", default-features = false, features = ["bytemuck"] }
-webbrowser = { version = "0.7", optional = true }
+webbrowser = { version = "0.8.2", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 arboard = { version = "2.0.1", optional = true }
 thread_local = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
-once_cell = "1.9.0"
-version-sync = "0.9.2"
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
+once_cell = "1.16.0"
+version-sync = "0.9.4"
+bevy = { version = "0.9.0", default-features = false, features = [
     "x11",
     "png",
     "bevy_pbr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ open_url = ["webbrowser"]
 default_fonts = ["egui/default_fonts"]
 
 [dependencies]
-bevy = { version = "0.8", default-features = false, features = ["bevy_render", "bevy_core_pipeline", "bevy_asset"] }
+bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["bevy_render", "bevy_core_pipeline", "bevy_asset"] }
 egui = { version = "0.19.0", default-features = false, features = ["bytemuck"] }
 webbrowser = { version = "0.7", optional = true }
 
@@ -32,7 +32,7 @@ thread_local = { version = "1.1.0", optional = true }
 [dev-dependencies]
 once_cell = "1.9.0"
 version-sync = "0.9.2"
-bevy = { version = "0.8", default-features = false, features = [
+bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
     "x11",
     "png",
     "bevy_pbr",

--- a/examples/render_to_image_widget.rs
+++ b/examples/render_to_image_widget.rs
@@ -30,7 +30,7 @@ struct PreviewPassCube;
 #[derive(Component)]
 struct MainPassCube;
 
-#[derive(Deref)]
+#[derive(Deref, Resource)]
 struct CubePreviewImage(Handle<Image>);
 
 fn setup(
@@ -83,7 +83,7 @@ fn setup(
 
     // The cube that will be rendered to the texture.
     commands
-        .spawn_bundle(PbrBundle {
+        .spawn(PbrBundle {
             mesh: cube_handle,
             material: preview_material_handle,
             transform: Transform::from_translation(Vec3::new(0.0, 0.0, 1.0)),
@@ -94,13 +94,13 @@ fn setup(
 
     // Light
     // NOTE: Currently lights are shared between passes - see https://github.com/bevyengine/bevy/issues/3462
-    commands.spawn_bundle(PointLightBundle {
+    commands.spawn(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(0.0, 0.0, 10.0)),
         ..default()
     });
 
     commands
-        .spawn_bundle(Camera3dBundle {
+        .spawn(Camera3dBundle {
             camera_3d: Camera3d {
                 clear_color: ClearColorConfig::Custom(Color::rgba(1.0, 1.0, 1.0, 0.0)),
                 ..default()
@@ -124,7 +124,7 @@ fn setup(
 
     // Main pass cube.
     commands
-        .spawn_bundle(PbrBundle {
+        .spawn(PbrBundle {
             mesh: cube_handle,
             material: main_material_handle,
             transform: Transform {
@@ -137,7 +137,7 @@ fn setup(
         .insert(MainPassCube);
 
     // The main pass camera.
-    commands.spawn_bundle(Camera3dBundle {
+    commands.spawn(Camera3dBundle {
         transform: Transform::from_translation(Vec3::new(0.0, 0.0, 15.0))
             .looking_at(Vec3::default(), Vec3::Y),
         ..default()

--- a/examples/side_panel.rs
+++ b/examples/side_panel.rs
@@ -1,7 +1,7 @@
 use bevy::{prelude::*, render::camera::Projection};
 use bevy_egui::{egui, EguiContext, EguiPlugin};
 
-#[derive(Default)]
+#[derive(Default, Resource)]
 struct OccupiedScreenSpace {
     left: f32,
     top: f32,
@@ -11,6 +11,7 @@ struct OccupiedScreenSpace {
 
 const CAMERA_TARGET: Vec3 = Vec3::ZERO;
 
+#[derive(Resource)]
 struct OriginalCameraTransform(Transform);
 
 fn main() {
@@ -67,18 +68,18 @@ fn setup_system(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    commands.spawn_bundle(PbrBundle {
+    commands.spawn(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
         material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
         ..Default::default()
     });
-    commands.spawn_bundle(PbrBundle {
+    commands.spawn(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
         material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         ..Default::default()
     });
-    commands.spawn_bundle(PointLightBundle {
+    commands.spawn(PointLightBundle {
         point_light: PointLight {
             intensity: 1500.0,
             shadows_enabled: true,
@@ -93,7 +94,7 @@ fn setup_system(
         Transform::from_translation(camera_pos).looking_at(CAMERA_TARGET, Vec3::Y);
     commands.insert_resource(OriginalCameraTransform(camera_transform));
 
-    commands.spawn_bundle(Camera3dBundle {
+    commands.spawn(Camera3dBundle {
         transform: camera_transform,
         ..Default::default()
     });

--- a/examples/two_windows.rs
+++ b/examples/two_windows.rs
@@ -8,6 +8,7 @@ use once_cell::sync::Lazy;
 
 static SECOND_WINDOW_ID: Lazy<WindowId> = Lazy::new(WindowId::new);
 
+#[derive(Resource)]
 struct Images {
     bevy_icon: Handle<Image>,
 }
@@ -51,7 +52,7 @@ fn create_new_window(mut create_window_events: EventWriter<CreateWindow>, mut co
         },
     });
     // second window camera
-    commands.spawn_bundle(Camera3dBundle {
+    commands.spawn(Camera3dBundle {
         camera: Camera {
             target: RenderTarget::Window(*SECOND_WINDOW_ID),
             ..Default::default()
@@ -72,7 +73,7 @@ struct UiState {
     input: String,
 }
 
-#[derive(Default)]
+#[derive(Default, Resource)]
 struct SharedUiState {
     shared_input: String,
 }

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -33,7 +33,7 @@ fn main() {
         .add_system(ui_example)
         .run();
 }
-#[derive(Default)]
+#[derive(Default, Resource)]
 struct UiState {
     label: String,
     value: f32,

--- a/src/egui_node.rs
+++ b/src/egui_node.rs
@@ -5,6 +5,7 @@ use crate::render_systems::{
 use bevy::{
     core::cast_slice,
     ecs::world::{FromWorld, World},
+    prelude::Resource,
     render::{
         render_graph::{Node, NodeRunError, RenderGraphContext},
         render_resource::{
@@ -26,6 +27,7 @@ use bevy::{
     window::WindowId,
 };
 
+#[derive(Resource)]
 pub struct EguiPipeline {
     pipeline: RenderPipeline,
 

--- a/src/egui_node.rs
+++ b/src/egui_node.rs
@@ -21,7 +21,7 @@ use bevy::{
             VertexStepMode,
         },
         renderer::{RenderContext, RenderDevice, RenderQueue},
-        texture::{BevyDefault, Image},
+        texture::Image,
         view::ExtractedWindows,
     },
     window::WindowId,
@@ -120,7 +120,7 @@ impl FromWorld for EguiPipeline {
                 module: &shader_module,
                 entry_point: "fs_main",
                 targets: &[Some(ColorTargetState {
-                    format: TextureFormat::bevy_default(),
+                    format: TextureFormat::Bgra8UnormSrgb,
                     blend: Some(BlendState {
                         color: BlendComponent {
                             src_factor: BlendFactor::One,
@@ -424,7 +424,10 @@ pub(crate) fn color_image_as_bevy_image(egui_image: &egui::ColorImage) -> Image 
         // We unmultiply Egui textures to premultiply them later in the fragment shader.
         // As user textures loaded as Bevy assets are not premultiplied (and there seems to be no
         // convenient way to convert them to premultiplied ones), we do the this with Egui ones.
-        .flat_map(|color| color.to_srgba_unmultiplied())
+        .flat_map(|color| {
+            let [r, g, b, a] = color.to_srgba_unmultiplied();
+            [b, g, r, a]
+        })
         .collect();
 
     Image::new(
@@ -435,6 +438,6 @@ pub(crate) fn color_image_as_bevy_image(egui_image: &egui::ColorImage) -> Image 
         },
         TextureDimension::D2,
         pixels,
-        TextureFormat::Rgba8UnormSrgb,
+        TextureFormat::Bgra8UnormSrgb,
     )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -670,7 +670,9 @@ pub fn setup_pipeline(render_graph: &mut RenderGraph, config: RenderGraphConfig)
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bevy::{render::settings::WgpuSettings, winit::WinitPlugin, DefaultPlugins};
+    use bevy::{
+        app::PluginGroup, render::settings::WgpuSettings, winit::WinitPlugin, DefaultPlugins,
+    };
 
     #[test]
     fn test_readme_deps() {
@@ -684,7 +686,7 @@ mod tests {
                 backends: None,
                 ..Default::default()
             })
-            .add_plugins_with(DefaultPlugins, |group| group.disable::<WinitPlugin>())
+            .add_plugins(DefaultPlugins.build().disable::<WinitPlugin>())
             .add_plugin(EguiPlugin)
             .update();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,13 +62,10 @@ use arboard::Clipboard;
 use bevy::{
     app::{App, CoreStage, Plugin, StartupStage},
     asset::{AssetEvent, Assets, Handle},
-    ecs::{
-        event::EventReader,
-        schedule::{ParallelSystemDescriptorCoercion, SystemLabel},
-        system::ResMut,
-    },
+    ecs::{event::EventReader, schedule::SystemLabel, system::ResMut},
     input::InputSystem,
     log,
+    prelude::{IntoSystemDescriptor, Resource},
     render::{render_graph::RenderGraph, texture::Image, RenderApp, RenderStage},
     utils::HashMap,
     window::WindowId,
@@ -77,6 +74,7 @@ use egui_node::EguiNode;
 use render_systems::EguiTransforms;
 #[cfg(all(feature = "manage_clipboard", not(target_arch = "wasm32")))]
 use std::cell::{RefCell, RefMut};
+use std::ops::Deref;
 #[cfg(all(feature = "manage_clipboard", not(target_arch = "wasm32")))]
 use thread_local::ThreadLocal;
 
@@ -84,7 +82,7 @@ use thread_local::ThreadLocal;
 pub struct EguiPlugin;
 
 /// A resource for storing global UI settings.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Resource)]
 pub struct EguiSettings {
     /// Global scale factor for egui widgets (`1.0` by default).
     ///
@@ -116,10 +114,58 @@ impl Default for EguiSettings {
     }
 }
 
+/// Wrap the `WindowId` to `EguiRenderOutput` hashmap
+#[derive(Resource)]
+pub struct EguiRenderOutputContainer(pub HashMap<WindowId, EguiRenderOutput>);
+
+impl Deref for EguiRenderOutputContainer {
+    type Target = HashMap<WindowId, EguiRenderOutput>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Wrap the `WindowId` to `EguiInput` hashmap
+#[derive(Resource)]
+pub struct EguiRenderInputContainer(pub HashMap<WindowId, EguiInput>);
+
+impl Deref for EguiRenderInputContainer {
+    type Target = HashMap<WindowId, EguiInput>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Wrap the `WindowId` to `EguiOutputContainer` hashmap
+#[derive(Resource)]
+pub struct EguiOutputContainer(pub HashMap<WindowId, EguiOutput>);
+
+impl Deref for EguiOutputContainer {
+    type Target = HashMap<WindowId, EguiOutput>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Wrap the `WindowId` to `WindowSize` hashmap
+#[derive(Resource)]
+pub struct EguiWindowSizeContainer(pub HashMap<WindowId, WindowSize>);
+
+impl Deref for EguiWindowSizeContainer {
+    type Target = HashMap<WindowId, WindowSize>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 /// Is used for storing the input passed to Egui. The actual resource is `HashMap<WindowId, EguiInput>`.
 ///
 /// It gets reset during the [`EguiSystem::ProcessInput`] system.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Resource)]
 pub struct EguiInput {
     /// Egui's raw input.
     pub raw_input: egui::RawInput,
@@ -129,7 +175,7 @@ pub struct EguiInput {
 ///
 /// The resource is available only if `manage_clipboard` feature is enabled.
 #[cfg(feature = "manage_clipboard")]
-#[derive(Default)]
+#[derive(Default, Resource)]
 pub struct EguiClipboard {
     #[cfg(not(target_arch = "wasm32"))]
     clipboard: ThreadLocal<Option<RefCell<Clipboard>>>,
@@ -198,7 +244,7 @@ impl EguiClipboard {
 }
 
 /// Is used for storing Egui shapes. The actual resource is `HashMap<WindowId, EguiShapes>`.
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default, Debug, Resource)]
 pub struct EguiRenderOutput {
     /// Pairs of rectangles and paint commands.
     ///
@@ -210,14 +256,14 @@ pub struct EguiRenderOutput {
 }
 
 /// Is used for storing Egui output. The actual resource is `HashMap<WindowId, EguiOutput>`.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Resource)]
 pub struct EguiOutput {
     /// The field gets updated during the [`EguiSystem::ProcessOutput`] system in the [`CoreStage::PostUpdate`].
     pub platform_output: egui::PlatformOutput,
 }
 
 /// A resource for storing `bevy_egui` context.
-#[derive(Clone)]
+#[derive(Clone, Resource)]
 pub struct EguiContext {
     ctx: HashMap<WindowId, egui::Context>,
     user_textures: HashMap<Handle<Image>, u64>,
@@ -433,10 +479,19 @@ impl Plugin for EguiPlugin {
     fn build(&self, app: &mut App) {
         let world = &mut app.world;
         world.insert_resource(EguiSettings::default());
-        world.insert_resource(HashMap::<WindowId, EguiInput>::default());
-        world.insert_resource(HashMap::<WindowId, EguiOutput>::default());
-        world.insert_resource(HashMap::<WindowId, WindowSize>::default());
-        world.insert_resource(HashMap::<WindowId, EguiRenderOutput>::default());
+        world.insert_resource(EguiRenderInputContainer(
+            HashMap::<WindowId, EguiInput>::default(),
+        ));
+        world.insert_resource(EguiOutputContainer(
+            HashMap::<WindowId, EguiOutput>::default(),
+        ));
+        world.insert_resource(EguiWindowSizeContainer(
+            HashMap::<WindowId, WindowSize>::default(),
+        ));
+        world.insert_resource(EguiRenderOutputContainer(HashMap::<
+            WindowId,
+            EguiRenderOutput,
+        >::default()));
         world.insert_resource(EguiManagedTextures::default());
         #[cfg(feature = "manage_clipboard")]
         world.insert_resource(EguiClipboard::default());
@@ -490,9 +545,10 @@ impl Plugin for EguiPlugin {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Resource)]
 pub(crate) struct EguiManagedTextures(HashMap<(WindowId, u64), EguiManagedTexture>);
 
+#[derive(Resource)]
 pub(crate) struct EguiManagedTexture {
     handle: Handle<Image>,
     /// Stored in full so we can do partial updates (which bevy doesn't support).
@@ -500,11 +556,11 @@ pub(crate) struct EguiManagedTexture {
 }
 
 fn update_egui_textures(
-    mut egui_render_output: ResMut<HashMap<WindowId, EguiRenderOutput>>,
+    mut egui_render_output: ResMut<EguiRenderOutputContainer>,
     mut egui_managed_textures: ResMut<EguiManagedTextures>,
     mut image_assets: ResMut<Assets<Image>>,
 ) {
-    for (&window_id, egui_render_output) in egui_render_output.iter_mut() {
+    for (&window_id, egui_render_output) in egui_render_output.0.iter_mut() {
         let set_textures = std::mem::take(&mut egui_render_output.textures_delta.set);
 
         for (texture_id, image_delta) in set_textures {
@@ -553,12 +609,12 @@ fn update_egui_textures(
 
 fn free_egui_textures(
     mut egui_context: ResMut<EguiContext>,
-    mut egui_render_output: ResMut<HashMap<WindowId, EguiRenderOutput>>,
+    mut egui_render_output: ResMut<EguiRenderOutputContainer>,
     mut egui_managed_textures: ResMut<EguiManagedTextures>,
     mut image_assets: ResMut<Assets<Image>>,
     mut image_events: EventReader<AssetEvent<Image>>,
 ) {
-    for (&window_id, egui_render_output) in egui_render_output.iter_mut() {
+    for (&window_id, egui_render_output) in egui_render_output.0.iter_mut() {
         let free_textures = std::mem::take(&mut egui_render_output.textures_delta.free);
         for texture_id in free_textures {
             if let egui::TextureId::Managed(texture_id) = texture_id {

--- a/src/render_systems.rs
+++ b/src/render_systems.rs
@@ -1,6 +1,6 @@
 use crate::{
-    egui_node::EguiPipeline, EguiContext, EguiManagedTextures, EguiRenderOutput, EguiSettings,
-    WindowSize,
+    egui_node::EguiPipeline, EguiContext, EguiManagedTextures, EguiRenderOutput,
+    EguiRenderOutputContainer, EguiSettings, EguiWindowSizeContainer, WindowSize,
 };
 use bevy::{
     asset::HandleId,
@@ -19,9 +19,13 @@ use bevy::{
     window::WindowId,
 };
 
+#[derive(Resource)]
 pub(crate) struct ExtractedRenderOutput(pub HashMap<WindowId, EguiRenderOutput>);
+#[derive(Resource)]
 pub(crate) struct ExtractedWindowSizes(pub HashMap<WindowId, WindowSize>);
+#[derive(Resource)]
 pub(crate) struct ExtractedEguiSettings(pub EguiSettings);
+#[derive(Resource)]
 pub(crate) struct ExtractedEguiContext(pub HashMap<WindowId, egui::Context>);
 
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -32,6 +36,7 @@ pub(crate) enum EguiTexture {
     User(u64),
 }
 
+#[derive(Resource)]
 pub(crate) struct ExtractedEguiTextures {
     pub(crate) egui_textures: HashMap<(WindowId, u64), Handle<Image>>,
     pub(crate) user_textures: HashMap<Handle<Image>, u64>,
@@ -42,20 +47,20 @@ impl ExtractedEguiTextures {
         self.egui_textures
             .iter()
             .map(|(&(window, texture_id), handle)| {
-                (EguiTexture::Managed(window, texture_id), handle.id)
+                (EguiTexture::Managed(window, texture_id), handle.id())
             })
             .chain(
                 self.user_textures
                     .iter()
-                    .map(|(handle, id)| (EguiTexture::User(*id), handle.id)),
+                    .map(|(handle, id)| (EguiTexture::User(*id), handle.id())),
             )
     }
 }
 
 pub(crate) fn extract_egui_render_data(
     mut commands: Commands,
-    egui_render_output: Extract<Res<HashMap<WindowId, EguiRenderOutput>>>,
-    window_sizes: Extract<Res<HashMap<WindowId, WindowSize>>>,
+    egui_render_output: Extract<Res<EguiRenderOutputContainer>>,
+    window_sizes: Extract<Res<EguiWindowSizeContainer>>,
     egui_settings: Extract<Res<EguiSettings>>,
     egui_context: Extract<Res<EguiContext>>,
 ) {
@@ -82,7 +87,7 @@ pub(crate) fn extract_egui_textures(
     });
 }
 
-#[derive(Default)]
+#[derive(Default, Resource)]
 pub(crate) struct EguiTransforms {
     pub buffer: DynamicUniformBuffer<EguiTransform>,
     pub offsets: HashMap<WindowId, u32>,
@@ -149,6 +154,7 @@ pub(crate) fn prepare_egui_transforms(
     }
 }
 
+#[derive(Resource)]
 pub(crate) struct EguiTextureBindGroups {
     pub(crate) bind_groups: HashMap<EguiTexture, BindGroup>,
 }


### PR DESCRIPTION
One of my projects has a rendering bug that is fixed on Bevy/main. Due to breaking changes in `0.9 dev`, I couldn't use bevy_egui anymore. This PR adopts all the bevy changes required to run bevy_egui with the current state of bevy 0.9 dev. Not sure if you already want to merge it, but I wanted to share it already in case anybody else is in my situation.