### PR TITLE
Fix panic due to missing swapchain texture.

### DIFF
--- a/src/egui_node.rs
+++ b/src/egui_node.rs
@@ -315,13 +315,13 @@ impl Node for EguiNode {
                 return Ok(()); // No window
             };
 
-        let swap_chain_texture = 
+        let swap_chain_texture =
             if let Some(swap_chain_texture) = extracted_window.swap_chain_texture.as_ref() {
                 swap_chain_texture
             } else {
                 return Ok(()); // No swapchain texture
             };
-            
+
         let render_queue = world.get_resource::<RenderQueue>().unwrap();
 
         let (vertex_buffer, index_buffer) = match (&self.vertex_buffer, &self.index_buffer) {

--- a/src/egui_node.rs
+++ b/src/egui_node.rs
@@ -315,6 +315,13 @@ impl Node for EguiNode {
                 return Ok(()); // No window
             };
 
+        let swap_chain_texture = 
+            if let Some(swap_chain_texture) = extracted_window.swap_chain_texture.as_ref() {
+                swap_chain_texture
+            } else {
+                return Ok(()); // No swapchain texture
+            };
+            
         let render_queue = world.get_resource::<RenderQueue>().unwrap();
 
         let (vertex_buffer, index_buffer) = match (&self.vertex_buffer, &self.index_buffer) {
@@ -328,8 +335,6 @@ impl Node for EguiNode {
         let bind_groups = &world.get_resource::<EguiTextureBindGroups>().unwrap();
 
         let egui_transforms = world.get_resource::<EguiTransforms>().unwrap();
-
-        let swap_chain_texture = extracted_window.swap_chain_texture.as_ref().unwrap();
 
         let mut render_pass =
             render_context


### PR DESCRIPTION
Fixes #136.

Because of some driver quirks, Bevy will ignore swapchain timeouts on some devices, as mentioned in bevyengine/bevy#5957. When this occurs, `extracted_window.swap_chain_texture` will be `None`.

Bevy handles this by bailing out of the render node early (see [here](https://github.com/bevyengine/bevy/blob/b3d59060db6bbe7c63b227510fd58460e1790dd9/crates/bevy_render/src/camera/camera_driver_node.rs#L81)), and this fix is implemented in the same way.