### PR TITLE
update arboard dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ egui = { version = "0.20.0", default-features = false, features = ["bytemuck"] }
 webbrowser = { version = "0.8.2", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-arboard = { version = "2.0.1", optional = true }
+arboard = { version = "3.2.0", optional = true }
 thread_local = { version = "1.1.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This gets rid of `image@0.23.14` in the dependency tree.

[ardboard 0.3 changes](https://github.com/1Password/arboard/blob/master/CHANGELOG.md#changed-3)