### PR TITLE
Bump `arboard` version to reduce duplicate deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ egui = { version = "0.20.0", default-features = false, features = ["bytemuck"] }
 webbrowser = { version = "0.8.2", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-arboard = { version = "3.2, optional = true }
+arboard = { version = "3.2", optional = true }
 thread_local = { version = "1.1.0", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ egui = { version = "0.20.0", default-features = false, features = ["bytemuck"] }
 webbrowser = { version = "0.8.2", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-arboard = { version = "2.0.1", optional = true }
+arboard = { version = "3.2, optional = true }
 thread_local = { version = "1.1.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Should fix https://github.com/Leafwing-Studios/Emergence/issues/194.

This is a first attempt: we'll see if CI passes and fix up any breaking changes if needed.