### PR TITLE
Fix ctrl or win interfering with character inputs

### DIFF
--- a/src/systems.rs
+++ b/src/systems.rs
@@ -240,7 +240,7 @@ pub fn process_input_system(
         }
     }
 
-    if !mac_cmd {
+    if !command || cfg!(target_os = "windows") && ctrl && alt {
         for event in input_events.ev_received_character.iter() {
             if !event.char.is_control() {
                 input_resources

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -240,14 +240,16 @@ pub fn process_input_system(
         }
     }
 
-    for event in input_events.ev_received_character.iter() {
-        if !event.char.is_control() {
-            input_resources
-                .egui_input
-                .get_mut(&event.id)
-                .unwrap()
-                .events
-                .push(egui::Event::Text(event.char.to_string()));
+    if !mac_cmd {
+        for event in input_events.ev_received_character.iter() {
+            if !event.char.is_control() {
+                input_resources
+                    .egui_input
+                    .get_mut(&event.id)
+                    .unwrap()
+                    .events
+                    .push(egui::Event::Text(event.char.to_string()));
+            }
         }
     }
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -240,16 +240,14 @@ pub fn process_input_system(
         }
     }
 
-    if !ctrl && !win {
-        for event in input_events.ev_received_character.iter() {
-            if !event.char.is_control() {
-                input_resources
-                    .egui_input
-                    .get_mut(&event.id)
-                    .unwrap()
-                    .events
-                    .push(egui::Event::Text(event.char.to_string()));
-            }
+    for event in input_events.ev_received_character.iter() {
+        if !event.char.is_control() {
+            input_resources
+                .egui_input
+                .get_mut(&event.id)
+                .unwrap()
+                .events
+                .push(egui::Event::Text(event.char.to_string()));
         }
     }
 


### PR DESCRIPTION
I'm building an app where I need users to enter a "at sign" (@), and input text is not allowing me to do that.

Looks like the issue is from bevy_egui.

My changes appear to fix it, but I didn't make a bigger background check on why that condition was there originally.

Other context as to how I ended up to this solution: https://discord.com/channels/691052431525675048/1072569924972728320