### PR TITLE
Fix recreation of EguiContext on startup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ use bevy::{
     prelude::{
         Added, Commands, Component, CoreSet, Deref, DerefMut, Entity, IntoSystemAppConfigs,
         IntoSystemConfig, IntoSystemConfigs, Query, Resource, Shader, StartupSet, SystemSet, With,
+        Without,
     },
     render::{
         render_resource::SpecializedRenderPipelines, texture::Image, ExtractSchedule, RenderApp,
@@ -639,7 +640,10 @@ pub struct EguiManagedTexture {
 }
 
 /// Adds bevy_egui components to newly created windows.
-pub fn setup_new_windows_system(mut commands: Commands, new_windows: Query<Entity, Added<Window>>) {
+pub fn setup_new_windows_system(
+    mut commands: Commands,
+    new_windows: Query<Entity, (Added<Window>, Without<EguiContext>)>,
+) {
     for window in new_windows.iter() {
         commands.entity(window).insert((
             EguiContext::default(),


### PR DESCRIPTION
`setup_new_windows_system` is added as both a `PreStartup` system and a `PreUpdate` system, and the `Query` will return the same `Added<Window>` for both. For window(s) created on startup, it will run again on the first frame and recreate the components, so any egui setup done with a startup system is lost.

One solution is to have the query omit any entities that already have an EguiContext.

Fixes #160