### PR TITLE
Fix incorrect bounds check for set_scissor_rect

### DIFF
--- a/src/egui_node.rs
+++ b/src/egui_node.rs
@@ -385,14 +385,16 @@ impl Node for EguiNode {
                 render_pass.set_scissor_rect(
                     draw_command.clipping_zone.0,
                     draw_command.clipping_zone.1,
-                    draw_command
-                        .clipping_zone
-                        .2
-                        .min(extracted_window.physical_width.saturating_sub(draw_command.clipping_zone.0)),
-                    draw_command
-                        .clipping_zone
-                        .3
-                        .min(extracted_window.physical_height.saturating_sub(draw_command.clipping_zone.1)),
+                    draw_command.clipping_zone.2.min(
+                        extracted_window
+                            .physical_width
+                            .saturating_sub(draw_command.clipping_zone.0),
+                    ),
+                    draw_command.clipping_zone.3.min(
+                        extracted_window
+                            .physical_height
+                            .saturating_sub(draw_command.clipping_zone.1),
+                    ),
                 );
 
                 render_pass.draw_indexed(

--- a/src/egui_node.rs
+++ b/src/egui_node.rs
@@ -388,11 +388,11 @@ impl Node for EguiNode {
                     draw_command
                         .clipping_zone
                         .2
-                        .min(extracted_window.physical_width),
+                        .min(extracted_window.physical_width.saturating_sub(draw_command.clipping_zone.0)),
                     draw_command
                         .clipping_zone
                         .3
-                        .min(extracted_window.physical_height),
+                        .min(extracted_window.physical_height.saturating_sub(draw_command.clipping_zone.1)),
                 );
 
                 render_pass.draw_indexed(


### PR DESCRIPTION
In `EguiNode::run`, an attempt is made to fix for bad scissor rect bounds by the width & height of the scissor rect to the physical window.
However, this only works if the scissor rect starts at (0, 0); if it isn't, then the scissor rect may still go out of bounds of the window.

This can cause a panic from wgpu when `window.resolution.set(x, y)` is called from WASM with a resolution *lower* than the current setting, as when the window updates, but the egui draw commands haven't been updated, the scissor rect can extend outside of the render target if it has an offset top-left corner.
![image](https://user-images.githubusercontent.com/8049998/226864747-26301b8f-3a3e-4969-bc9b-c4da9f819051.png)

This PR changes it so that the scissor rect bound check subtracts the upper left coordinate, ensuring that the scissor rect remains within the bounds of the window even if the draw command doesn't originate at the top left.

I have tested and confirmed this change fixes the panic and doesn't appear to have any rendering inconsistencies either from WASM or Windows.