### PR TITLE
Accept NumpadEnter as Enter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 
 //! This crate provides a [Egui](https://github.com/emilk/egui) integration for the [Bevy](https://github.com/bevyengine/bevy) game engine.
 //!

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -444,6 +444,7 @@ fn bevy_to_egui_key(key_code: KeyCode) -> Option<egui::Key> {
         KeyCode::Tab => egui::Key::Tab,
         KeyCode::Back => egui::Key::Backspace,
         KeyCode::Return => egui::Key::Enter,
+        KeyCode::NumpadEnter => egui::Key::Enter,
         KeyCode::Space => egui::Key::Space,
         KeyCode::Insert => egui::Key::Insert,
         KeyCode::Delete => egui::Key::Delete,


### PR DESCRIPTION
Just a single line of code added to be able to use NumpadEnter. See  [Issue #170](https://github.com/mvlabat/bevy_egui/issues/170).

To get this to compile I did have to change the level of `missing_docs` as the compiler complains of the `WorldQuery` derive macro being undocumented. See bevy [Issue #3492](https://github.com/bevyengine/bevy/issues/3492), the crate `bevy_ecs_macros` is not yet documented enough. Once that is fixed, then the level of documentation can go back up to `deny` (under a separate PR).

