### PR TITLE
Changes for bevy 0.11-dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default_fonts = ["egui/default_fonts"]
 serde = ["egui/serde"]
 
 [dependencies]
-bevy = { version = "0.10", default-features = false, features = ["bevy_render", "bevy_asset"] }
+bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = ["bevy_render", "bevy_asset"] }
 egui = { version = "0.21.0", default-features = false, features = ["bytemuck"] }
 webbrowser = { version = "0.8.2", optional = true }
 
@@ -33,7 +33,7 @@ thread_local = { version = "1.1.0", optional = true }
 [dev-dependencies]
 once_cell = "1.16.0"
 version-sync = "0.9.4"
-bevy = { version = "0.10", default-features = false, features = [
+bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = [
     "x11",
     "png",
     "bevy_pbr",

--- a/examples/render_to_image_widget.rs
+++ b/examples/render_to_image_widget.rs
@@ -16,9 +16,8 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(EguiPlugin)
-        .add_startup_system(setup)
-        .add_system(rotator_system)
-        .add_system(render_to_image_example_system)
+        .add_systems(Startup, setup)
+        .add_systems(Update, (rotator_system, render_to_image_example_system))
         .run();
 }
 

--- a/examples/side_panel.rs
+++ b/examples/side_panel.rs
@@ -19,9 +19,8 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(EguiPlugin)
         .init_resource::<OccupiedScreenSpace>()
-        .add_startup_system(setup_system)
-        .add_system(ui_example_system)
-        .add_system(update_camera_transform_system)
+        .add_systems(Startup, setup_system)
+        .add_systems(Update, (ui_example_system, update_camera_transform_system))
         .run();
 }
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -7,7 +7,7 @@ fn main() {
         .add_plugin(EguiPlugin)
         // Systems that create Egui widgets should be run during the `CoreSet::Update` set,
         // or after the `EguiSet::BeginFrame` system (which belongs to the `CoreSet::PreUpdate` set).
-        .add_system(ui_example_system)
+        .add_systems(Update, ui_example_system)
         .run();
 }
 

--- a/examples/two_windows.rs
+++ b/examples/two_windows.rs
@@ -11,16 +11,13 @@ struct Images {
 }
 
 fn main() {
-    let mut app = App::new();
-    app.add_plugins(DefaultPlugins)
+    App::new()
+        .add_plugins(DefaultPlugins)
         .add_plugin(EguiPlugin)
         .init_resource::<SharedUiState>()
-        .add_startup_system(load_assets_system)
-        .add_startup_system(create_new_window_system)
-        .add_system(ui_first_window_system)
-        .add_system(ui_second_window_system);
-
-    app.run();
+        .add_systems(Startup, (load_assets_system, create_new_window_system))
+        .add_systems(Update, (ui_first_window_system, ui_second_window_system))
+        .run();
 }
 
 fn create_new_window_system(mut commands: Commands) {

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -27,10 +27,8 @@ fn main() {
         .init_resource::<UiState>()
         .add_plugins(DefaultPlugins)
         .add_plugin(EguiPlugin)
-        .add_startup_system(configure_visuals_system)
-        .add_startup_system(configure_ui_state_system)
-        .add_system(update_ui_scale_factor_system)
-        .add_system(ui_example_system)
+        .add_systems(Startup, (configure_visuals_system, configure_ui_state_system))
+        .add_systems(Update, (update_ui_scale_factor_system, ui_example_system))
         .run();
 }
 #[derive(Default, Resource)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 
 //! This crate provides a [Egui](https://github.com/emilk/egui) integration for the [Bevy](https://github.com/bevyengine/bevy) game engine.
 //!
@@ -79,13 +79,11 @@ use bevy::{
     input::InputSystem,
     log,
     prelude::{
-        Added, Commands, Component, CoreSet, Deref, DerefMut, Entity, IntoSystemAppConfigs,
-        IntoSystemConfig, IntoSystemConfigs, Query, Resource, Shader, StartupSet, SystemSet, With,
-        Without,
+        Added, Commands, Component, Deref, DerefMut, Entity, IntoSystemConfigs, Last, PostUpdate,
+        PreStartup, PreUpdate, Query, Resource, Shader, SystemSet, With, Without,
     },
     render::{
-        render_resource::SpecializedRenderPipelines, texture::Image, ExtractSchedule, RenderApp,
-        RenderSet,
+        render_resource::SpecializedRenderPipelines, texture::Image, ExtractSchedule, Render, RenderApp, RenderSet,
     },
     utils::HashMap,
     window::{PrimaryWindow, Window},
@@ -533,50 +531,50 @@ impl Plugin for EguiPlugin {
         world.init_resource::<EguiUserTextures>();
         world.init_resource::<EguiMousePosition>();
 
-        app.add_startup_systems(
+        app.add_systems(
+            PreStartup,
             (
                 setup_new_windows_system,
                 apply_system_buffers,
                 update_window_contexts_system,
             )
                 .chain()
-                .in_set(EguiStartupSet::InitContexts)
-                .in_base_set(StartupSet::PreStartup),
+                .in_set(EguiStartupSet::InitContexts),
         );
         app.add_systems(
+            PreUpdate,
             (
                 setup_new_windows_system,
                 apply_system_buffers,
                 update_window_contexts_system,
             )
                 .chain()
-                .in_set(EguiSet::InitContexts)
-                .in_base_set(CoreSet::PreUpdate),
+                .in_set(EguiSet::InitContexts),
         );
-        app.add_system(
+        app.add_systems(
+            PreUpdate,
             process_input_system
                 .in_set(EguiSet::ProcessInput)
                 .after(InputSystem)
-                .after(EguiSet::InitContexts)
-                .in_base_set(CoreSet::PreUpdate),
+                .after(EguiSet::InitContexts),
         );
-        app.add_system(
+        app.add_systems(
+            PreUpdate,
             begin_frame_system
                 .in_set(EguiSet::BeginFrame)
-                .after(EguiSet::ProcessInput)
-                .in_base_set(CoreSet::PreUpdate),
+                .after(EguiSet::ProcessInput),
         );
-        app.add_system(
+        app.add_systems(
+            PostUpdate,
             process_output_system
-                .in_set(EguiSet::ProcessOutput)
-                .in_base_set(CoreSet::PostUpdate),
+                .in_set(EguiSet::ProcessOutput),
         );
-        app.add_system(
+        app.add_systems(
+            PostUpdate,
             update_egui_textures_system
-                .after(EguiSet::ProcessOutput)
-                .in_base_set(CoreSet::PostUpdate),
+                .after(EguiSet::ProcessOutput),
         );
-        app.add_system(free_egui_textures_system.in_base_set(CoreSet::Last));
+        app.add_systems(Last, free_egui_textures_system);
 
         let mut shaders = app.world.resource_mut::<Assets<Shader>>();
         shaders.set_untracked(
@@ -590,19 +588,26 @@ impl Plugin for EguiPlugin {
                 .init_resource::<SpecializedRenderPipelines<EguiPipeline>>()
                 .init_resource::<EguiTransforms>()
                 .add_systems(
+                    ExtractSchedule,
                     (
                         render_systems::extract_egui_render_data_system,
                         render_systems::extract_egui_textures_system,
                         render_systems::setup_new_windows_render_system,
                     )
-                        .into_configs()
-                        .in_schedule(ExtractSchedule),
+                        .into_configs(),
                 )
-                .add_system(
+                .add_systems(
+                    Render,
                     render_systems::prepare_egui_transforms_system.in_set(RenderSet::Prepare),
                 )
-                .add_system(render_systems::queue_bind_groups_system.in_set(RenderSet::Queue))
-                .add_system(render_systems::queue_pipelines_system.in_set(RenderSet::Queue));
+                .add_systems(
+                    Render,
+                    render_systems::queue_bind_groups_system.in_set(RenderSet::Queue)
+                )
+                .add_systems(
+                    Render,
+                    render_systems::queue_pipelines_system.in_set(RenderSet::Queue)
+                );
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,8 @@
 //!     App::new()
 //!         .add_plugins(DefaultPlugins)
 //!         .add_plugin(EguiPlugin)
-//!         // Systems that create Egui widgets should be run during the `CoreSet::Update` set,
-//!         // or after the `EguiSet::BeginFrame` system (which belongs to the `CoreSet::PreUpdate` set).
+//!         // Systems that create Egui widgets should be run during the `Update` set,
+//!         // or after the `EguiSet::BeginFrame` system (which belongs to the `PreUpdate` set).
 //!         .add_system(ui_example_system)
 //!         .run();
 //! }
@@ -83,7 +83,8 @@ use bevy::{
         PreStartup, PreUpdate, Query, Resource, Shader, SystemSet, With, Without,
     },
     render::{
-        render_resource::SpecializedRenderPipelines, texture::Image, ExtractSchedule, Render, RenderApp, RenderSet,
+        render_resource::SpecializedRenderPipelines, texture::Image, ExtractSchedule, Render,
+        RenderApp, RenderSet,
     },
     utils::HashMap,
     window::{PrimaryWindow, Window},
@@ -213,7 +214,7 @@ impl EguiClipboard {
 pub struct EguiRenderOutput {
     /// Pairs of rectangles and paint commands.
     ///
-    /// The field gets populated during the [`EguiSet::ProcessOutput`] system (belonging to [`CoreSet::PostUpdate`]) and reset during `EguiNode::update`.
+    /// The field gets populated during the [`EguiSet::ProcessOutput`] system (belonging to [`PostUpdate`]) and reset during `EguiNode::update`.
     pub paint_jobs: Vec<egui::ClippedPrimitive>,
 
     /// The change in egui textures since last frame.
@@ -223,7 +224,7 @@ pub struct EguiRenderOutput {
 /// Is used for storing Egui output.
 #[derive(Component, Clone, Default)]
 pub struct EguiOutput {
-    /// The field gets updated during the [`EguiSet::ProcessOutput`] system (belonging to [`CoreSet::PostUpdate`]).
+    /// The field gets updated during the [`EguiSet::ProcessOutput`] system (belonging to [`PostUpdate`]).
     pub platform_output: egui::PlatformOutput,
 }
 
@@ -566,13 +567,11 @@ impl Plugin for EguiPlugin {
         );
         app.add_systems(
             PostUpdate,
-            process_output_system
-                .in_set(EguiSet::ProcessOutput),
+            process_output_system.in_set(EguiSet::ProcessOutput),
         );
         app.add_systems(
             PostUpdate,
-            update_egui_textures_system
-                .after(EguiSet::ProcessOutput),
+            update_egui_textures_system.after(EguiSet::ProcessOutput),
         );
         app.add_systems(Last, free_egui_textures_system);
 
@@ -602,11 +601,11 @@ impl Plugin for EguiPlugin {
                 )
                 .add_systems(
                     Render,
-                    render_systems::queue_bind_groups_system.in_set(RenderSet::Queue)
+                    render_systems::queue_bind_groups_system.in_set(RenderSet::Queue),
                 )
                 .add_systems(
                     Render,
-                    render_systems::queue_pipelines_system.in_set(RenderSet::Queue)
+                    render_systems::queue_pipelines_system.in_set(RenderSet::Queue),
                 );
         }
     }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -143,12 +143,13 @@ pub fn process_input_system(
         // that has been left.
         if cursor_left_window != Some(cursor_moved.window) {
             let scale_factor = egui_settings.scale_factor as f32;
-            let mut mouse_position: (f32, f32) = (cursor_moved.position / scale_factor).into();
+            let mouse_position: (f32, f32) = (cursor_moved.position / scale_factor).into();
             let mut context = context_params
                 .contexts
                 .get_mut(cursor_moved.window)
                 .unwrap();
-            mouse_position.1 = context.window_size.height() / scale_factor - mouse_position.1;
+            // Breaks with bevy#8306 changing flipping the y coordinate
+            // mouse_position.1 = context.window_size.height() / scale_factor - mouse_position.1;
             egui_mouse_position.0 = Some((cursor_moved.window, mouse_position.into()));
             context
                 .egui_input


### PR DESCRIPTION
This is a draft version of the changes needed for this project to work with bevy-main.

The main change is the new [`add_systems`](https://github.com/bevyengine/bevy/pull/8079), which now takes the schedule pattern as a first parameter and a tuple of systems as the second. `add_system` (singular) is now deprecated.

Another breaking change was [flipping the y coordinate](https://github.com/bevyengine/bevy/commit/585baf0a66b855cef1f0568a4af44b666cfee076) for consistency. This means we can remove the inverted mouse in the `process_input_system`.

Will add more to this draft if there are further breaking changes.