### PR TITLE
Fix `@` on AZERTY on wasm

### DIFF
--- a/src/systems.rs
+++ b/src/systems.rs
@@ -210,15 +210,13 @@ pub fn process_input_system(
         }
     }
 
-    if !command || cfg!(target_os = "windows") && ctrl && alt {
-        for event in input_events.ev_received_character.iter() {
-            if !event.char.is_control() {
-                let mut context = context_params.contexts.get_mut(event.window).unwrap();
-                context
-                    .egui_input
-                    .events
-                    .push(egui::Event::Text(event.char.to_string()));
-            }
+    for event in input_events.ev_received_character.iter() {
+        if !event.char.is_control() {
+            let mut context = context_params.contexts.get_mut(event.window).unwrap();
+            context
+                .egui_input
+                .events
+                .push(egui::Event::Text(event.char.to_string()));
         }
     }
 


### PR DESCRIPTION
Follow up on https://github.com/mvlabat/bevy_egui/pull/149 ; I'm building on wasm and realized my fix is not sufficient, I can't input `@` on wasm :'(.

In https://github.com/mvlabat/bevy_egui/pull/149 we did a minimal change by checking only windows, but I think we're overly conservative, I'd like to discuss why this condition is needed, and make proper tests about it to validate its usefulness.