### PR TITLE
Bump version, update egui/bevy dependency version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.4] - 28-May-2023
+
+Update `bevy` dependency to 0.10.1
+Update `egui` dependency to 0.22.0
+
 ## [0.20.3] - 21-Apr-2023
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_egui"
-version = "0.20.3"
+version = "0.20.4"
 authors = ["mvlabat <mvlabat@gmail.com>"]
 description = "A plugin for Egui integration into Bevy"
 license = "MIT"
@@ -22,8 +22,8 @@ default_fonts = ["egui/default_fonts"]
 serde = ["egui/serde"]
 
 [dependencies]
-bevy = { version = "0.10", default-features = false, features = ["bevy_render", "bevy_asset"] }
-egui = { version = "0.21.0", default-features = false, features = ["bytemuck"] }
+bevy = { version = "0.10.1", default-features = false, features = ["bevy_render", "bevy_asset"] }
+egui = { version = "0.22.0", default-features = false, features = ["bytemuck"] }
 webbrowser = { version = "0.8.2", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -33,7 +33,7 @@ thread_local = { version = "1.1.0", optional = true }
 [dev-dependencies]
 once_cell = "1.16.0"
 version-sync = "0.9.4"
-bevy = { version = "0.10", default-features = false, features = [
+bevy = { version = "0.10.1", default-features = false, features = [
     "x11",
     "png",
     "bevy_pbr",


### PR DESCRIPTION
- Updates Bevy dependency to be the latest @ 0.10.1
- Updates Egui dependency to be the latest @ 0.22.0

And bump the crate version to 0.20.4, as the change as not backwards compatible for projects pinned at different bevy/egui versions. 

Perhaps there's a better way to make bevy_egui agnostic to specific bevy/egui versions? They're pre-1.x.y, so semver doesn't make compatibility guarentees, but I'm hoping the crates don't have to be pinned at the patch version.