### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,17 +11,12 @@ jobs:
     name: Formatter check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: nightly
-          override: true
           components: rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy check
@@ -37,14 +32,12 @@ jobs:
             'manage_clipboard,open_url',
         ]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
-          override: true
           components: clippy
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -57,10 +50,7 @@ jobs:
       - name: Install dependencies
         if: runner.os == 'Linux'
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --no-default-features --all-targets --features=${{ matrix.features }} -- -D warnings
+      - run: cargo clippy --no-default-features --all-targets --features=${{ matrix.features }} -- -D warnings
 
   clippy_wasm32:
     name: Clippy check (wasm32)
@@ -75,15 +65,13 @@ jobs:
             'manage_clipboard,open_url',
         ]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
-          override: true
           components: clippy
-          target: wasm32-unknown-unknown
-      - uses: actions/cache@v2
+          targets: wasm32-unknown-unknown
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -93,22 +81,17 @@ jobs:
           restore-keys: |
             cache-wasm32-cargo-${{ hashFiles('**/Cargo.toml') }}
             cache-wasm32-cargo
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --no-default-features --target=wasm32-unknown-unknown --all-targets --features=${{ matrix.features }} -- -D warnings
+      - run: cargo clippy --no-default-features --target=wasm32-unknown-unknown --all-targets --features=${{ matrix.features }} -- -D warnings
 
   doc:
     name: Check documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
-          override: true
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -118,10 +101,7 @@ jobs:
           restore-keys: |
             cache-doc-cargo-${{ hashFiles('**/Cargo.toml') }}
             cache-doc-cargo
-      - uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --all --features "bevy/x11"
+      - run: cargo doc --all --features "bevy/x11"
         env:
           RUSTDOCFLAGS: -D warnings
 
@@ -129,13 +109,11 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
-          override: true
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -147,7 +125,4 @@ jobs:
             cache-test-cargo
       - name: Install dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all
+      - run: cargo test --all


### PR DESCRIPTION
The following updates are performed:
* update [`actions/cache`](https://github.com/actions/cache) to v3
* update [`actions/checkout`](https://github.com/actions/checkout) to v3
* replace [unmaintained](https://github.com/actions-rs/toolchain/issues/216) `actions-rs/toolchain` by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain)
* replace unmaintained `actions-rs/cargo` by direct invocation of `cargo`

Still using the outdated / unmaintained actions will generate several warnings in CI runs, for example in https://github.com/mvlabat/bevy_egui/actions/runs/4763363890:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions-rs/toolchain@v1, actions/cache@v2, actions-rs/cargo@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings.