### PR TITLE
Simplify extraction by using derive

### DIFF
--- a/src/egui_node.rs
+++ b/src/egui_node.rs
@@ -1,9 +1,8 @@
 use crate::{
     render_systems::{
         EguiPipelines, EguiTextureBindGroups, EguiTextureId, EguiTransform, EguiTransforms,
-        ExtractedEguiSettings,
     },
-    EguiRenderOutput, WindowSize,
+    EguiRenderOutput, EguiSettings, WindowSize,
 };
 use bevy::{
     core::cast_slice,
@@ -199,7 +198,7 @@ impl Node for EguiNode {
         let window_size = *window_size;
         let paint_jobs = std::mem::take(&mut render_output.paint_jobs);
 
-        let egui_settings = &world.get_resource::<ExtractedEguiSettings>().unwrap();
+        let egui_settings = &world.get_resource::<EguiSettings>().unwrap();
 
         let render_device = world.get_resource::<RenderDevice>().unwrap();
 

--- a/src/render_systems.rs
+++ b/src/render_systems.rs
@@ -1,6 +1,6 @@
 use crate::{
     egui_node::{EguiNode, EguiPipeline, EguiPipelineKey},
-    EguiContextQueryReadOnly, EguiManagedTextures, EguiSettings, EguiUserTextures, WindowSize,
+    EguiManagedTextures, EguiSettings, EguiUserTextures, WindowSize,
 };
 use bevy::{
     asset::HandleId,
@@ -20,10 +20,6 @@ use bevy::{
     },
     utils::HashMap,
 };
-
-/// Extracted Egui settings.
-#[derive(Resource, Deref, DerefMut, Default)]
-pub struct ExtractedEguiSettings(pub EguiSettings);
 
 /// Corresponds to Egui's [`egui::TextureId`].
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -75,20 +71,6 @@ pub fn setup_new_windows_render_system(
             bevy::render::main_graph::node::CAMERA_DRIVER,
             egui_pass.to_string(),
         );
-    }
-}
-
-/// Extracts Egui context, render output, settings and application window sizes.
-pub fn extract_egui_render_data_system(
-    mut commands: Commands,
-    egui_settings: Extract<Res<EguiSettings>>,
-    contexts: Extract<Query<EguiContextQueryReadOnly>>,
-) {
-    commands.insert_resource(ExtractedEguiSettings(egui_settings.clone()));
-    for context in contexts.iter() {
-        commands
-            .get_or_spawn(context.window_entity)
-            .insert((*context.window_size, context.render_output.clone()));
     }
 }
 
@@ -147,7 +129,7 @@ impl EguiTransform {
 pub fn prepare_egui_transforms_system(
     mut egui_transforms: ResMut<EguiTransforms>,
     window_sizes: Query<(Entity, &WindowSize)>,
-    egui_settings: Res<ExtractedEguiSettings>,
+    egui_settings: Res<EguiSettings>,
 
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,


### PR DESCRIPTION
This PR simplifies extraction of resources by leveraging the standard `ExtractComponentPlugin` along with the `ExtractCompont` trait: Read more [here](https://docs.rs/bevy_render/latest/bevy_render/extract_component/index.html).

I opted to put `Egui*Textures` in a separate PR (#210), because it was maybe simpler to review