### PR TITLE
Added worldspace UI

### DIFF
--- a/src/egui_node.rs
+++ b/src/egui_node.rs
@@ -1,9 +1,8 @@
 use crate::{
     render_systems::{
         EguiPipelines, EguiTextureBindGroups, EguiTextureId, EguiTransform, EguiTransforms,
-        ExtractedEguiSettings,
     },
-    EguiRenderOutput, WindowSize,
+    EguiRenderOutput, EguiSettings, WindowSize,
 };
 use bevy::{
     core::cast_slice,
@@ -199,7 +198,7 @@ impl Node for EguiNode {
         let window_size = *window_size;
         let paint_jobs = std::mem::take(&mut render_output.paint_jobs);
 
-        let egui_settings = &world.get_resource::<ExtractedEguiSettings>().unwrap();
+        let egui_settings = &world.get_resource::<EguiSettings>().unwrap();
 
         let render_device = world.get_resource::<RenderDevice>().unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub use egui;
 
 use crate::{
     egui_node::{EguiPipeline, EGUI_SHADER_HANDLE},
-    render_systems::EguiTransforms,
+    render_systems::{EguiTransforms, ExtractedEguiManagedTextures},
     systems::*,
 };
 #[cfg(all(feature = "manage_clipboard", not(target_arch = "wasm32")))]
@@ -471,7 +471,7 @@ impl<'w, 's> EguiContexts<'w, 's> {
 pub struct EguiMousePosition(pub Option<(Entity, egui::Vec2)>);
 
 /// A resource for storing `bevy_egui` user textures.
-#[derive(Clone, Resource, Default)]
+#[derive(Clone, Resource, Default, ExtractResource)]
 pub struct EguiUserTextures {
     textures: HashMap<Handle<Image>, u64>,
     last_texture_id: u64,
@@ -580,6 +580,8 @@ impl Plugin for EguiPlugin {
         world.init_resource::<EguiMousePosition>();
         world.insert_resource(TouchId::default());
         app.add_plugins(ExtractResourcePlugin::<EguiSettings>::default());
+        app.add_plugins(ExtractResourcePlugin::<EguiUserTextures>::default());
+        app.add_plugins(ExtractResourcePlugin::<ExtractedEguiManagedTextures>::default());
         app.add_plugins(ExtractComponentPlugin::<EguiContext>::default());
         app.add_plugins(ExtractComponentPlugin::<WindowSize>::default());
         app.add_plugins(ExtractComponentPlugin::<EguiRenderOutput>::default());
@@ -650,11 +652,7 @@ impl Plugin for EguiPlugin {
                 .init_resource::<EguiTransforms>()
                 .add_systems(
                     ExtractSchedule,
-                    (
-                        render_systems::setup_new_windows_render_system,
-                        render_systems::extract_egui_textures_system,
-                    )
-                        .into_configs(),
+                    render_systems::setup_new_windows_render_system,
                 )
                 .add_systems(
                     Render,

--- a/src/render_systems.rs
+++ b/src/render_systems.rs
@@ -1,6 +1,6 @@
 use crate::{
     egui_node::{EguiNode, EguiPipeline, EguiPipelineKey},
-    EguiContextQueryReadOnly, EguiManagedTextures, EguiSettings, EguiUserTextures, WindowSize,
+    EguiManagedTextures, EguiSettings, EguiUserTextures, WindowSize,
 };
 use bevy::{
     asset::HandleId,
@@ -20,10 +20,6 @@ use bevy::{
     },
     utils::HashMap,
 };
-
-/// Extracted Egui settings.
-#[derive(Resource, Deref, DerefMut, Default)]
-pub struct ExtractedEguiSettings(pub EguiSettings);
 
 /// Corresponds to Egui's [`egui::TextureId`].
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -75,20 +71,6 @@ pub fn setup_new_windows_render_system(
             bevy::render::main_graph::node::CAMERA_DRIVER,
             egui_pass.to_string(),
         );
-    }
-}
-
-/// Extracts Egui context, render output, settings and application window sizes.
-pub fn extract_egui_render_data_system(
-    mut commands: Commands,
-    egui_settings: Extract<Res<EguiSettings>>,
-    contexts: Extract<Query<EguiContextQueryReadOnly>>,
-) {
-    commands.insert_resource(ExtractedEguiSettings(egui_settings.clone()));
-    for context in contexts.iter() {
-        commands
-            .get_or_spawn(context.window_entity)
-            .insert((*context.window_size, context.render_output.clone()));
     }
 }
 
@@ -147,7 +129,7 @@ impl EguiTransform {
 pub fn prepare_egui_transforms_system(
     mut egui_transforms: ResMut<EguiTransforms>,
     window_sizes: Query<(Entity, &WindowSize)>,
-    egui_settings: Res<ExtractedEguiSettings>,
+    egui_settings: Res<EguiSettings>,
 
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,


### PR DESCRIPTION
Rebased on #210 and #211.

Adds worldspace UI to `bevy_egui` via the `EguiRenderToTexture` component. Handling input is not implemented in this PR.

This PR is marked as a draft, because I thought that I could have multiple StandardMaterials on the same mesh, but that is not the case right now in bevy. This means that a user cannot easily have a base texture and then apply the egui overlaid transparently on top.

I think the right solution is likely to include an `EguiMaterial` as part of this plugin for users' convenience, and keep the `EguiRenderToTexture` as an option for people to use if they want to create their own custom materials. I don't have any experience with bevy materials yet, so I will revisit that later.

I'm also not particularly happy with my refactor - I feel like the systems could be redesigned a bit to help unify the branching logic of windows vs textures.