### PR TITLE
Handle giving time input to egui correctly

### DIFF
--- a/src/systems.rs
+++ b/src/systems.rs
@@ -359,7 +359,7 @@ pub fn process_input_system(
     }
 
     for mut context in context_params.contexts.iter_mut() {
-        context.egui_input.predicted_dt = time.delta_seconds();
+        context.egui_input.time = Some(time.elapsed_seconds_f64());
     }
 
     // In some cases, we may skip certain events. For example, we ignore `ReceivedCharacter` events


### PR DESCRIPTION
The predicted_dt should be based on the target framerate and not depend on frame-to-frame fluctuations. Instead, we can pass total elapsed time instead to let egui handle things correctly.