### PR TITLE
Add render feature to allow crates use bevy_egui that do not use bevy_render feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,16 +14,16 @@ all-features = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-default = ["manage_clipboard", "open_url", "default_fonts"]
+default = ["manage_clipboard", "open_url", "default_fonts", "render"]
 immutable_ctx = []
 manage_clipboard = ["arboard", "thread_local"]
 open_url = ["webbrowser"]
 default_fonts = ["egui/default_fonts"]
+render = ["bevy/bevy_render"]
 serde = ["egui/serde"]
 
 [dependencies]
 bevy = { version = "0.12", default-features = false, features = [
-    "bevy_render",
     "bevy_asset",
 ] }
 egui = { version = "0.24.0", default-features = false, features = ["bytemuck"] }


### PR DESCRIPTION
I added a `render` feature that is enabled by default to allow applications that want to use `bevy_egui` (but are not using `bevy_render` because they have a own rendering plugin), do not need to fully reimplement `bevy_egui` on their own and just disable the `bevy_render` dependent stuff :)