### PR TITLE
Fix requested repaints not causing Bevy to redraw.

### DIFF
--- a/src/systems.rs
+++ b/src/systems.rs
@@ -428,7 +428,7 @@ pub fn process_output_system(
             shapes,
             textures_delta,
             pixels_per_point,
-            viewport_output,
+            viewport_output: _,
         } = full_output;
         let paint_jobs = ctx.tessellate(shapes, pixels_per_point);
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -458,7 +458,7 @@ pub fn process_output_system(
         #[cfg(not(windows))]
         set_icon();
 
-        if viewport_output.is_empty() {
+        if ctx.has_requested_repaint() {
             event.send(RequestRedraw)
         }
 


### PR DESCRIPTION
The previous implementation seems to have lost track of what the redraw was supposed to be tracking. This meant button clicks would **not** trigger a redraw on `WinitSettings::desktop_app()` (only a mouse move after would cause a redraw).

I've tested this on my own project and things work much more correct!

Fixes #239.