### PR TITLE
disable manage clipboard for wasm32 AND android

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -82,6 +82,73 @@ jobs:
             cache-wasm32-cargo
       - run: cargo clippy --no-default-features --target=wasm32-unknown-unknown --all-targets --features=${{ matrix.features }} -- -D warnings
 
+  clippy_android:
+    name: Clippy check (android)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        features:
+          [
+            "immutable_ctx",
+            "manage_clipboard",
+            "open_url",
+            "manage_clipboard,open_url",
+          ]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: clippy
+          targets: aarch64-linux-android
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cache-android-cargo-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            cache-android-cargo-${{ hashFiles('**/Cargo.toml') }}
+            cache-android-cargo
+      - run: |
+          CC=$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android34-clang \
+          AR=$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar \
+          cargo clippy --target=aarch64-linux-android --no-default-features --all-targets --features=${{ matrix.features }} -- -D warnings
+
+  clippy_ios:
+    name: Clippy check (ios)
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        features:
+          [
+            "immutable_ctx",
+            "manage_clipboard",
+            "open_url",
+            "manage_clipboard,open_url",
+          ]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: clippy
+          targets: aarch64-apple-ios
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cache-ios-cargo-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            cache-ios-cargo-${{ hashFiles('**/Cargo.toml') }}
+            cache-ios-cargo
+      - run: cargo clippy --target=aarch64-apple-ios --no-default-features --all-targets --features=${{ matrix.features }} -- -D warnings
+
   doc:
     name: Check documentation
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ bevy = { version = "0.12", default-features = false, features = [
 egui = { version = "0.24.0", default-features = false, features = ["bytemuck"] }
 webbrowser = { version = "0.8.2", optional = true }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
 arboard = { version = "3.2.0", optional = true }
 thread_local = { version = "1.1.0", optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,11 @@ use crate::{
     render_systems::{EguiTransforms, ExtractedEguiManagedTextures},
     systems::*,
 };
-
+#[cfg(all(
+    feature = "manage_clipboard",
+    not(any(target_arch = "wasm32", target_os = "android"))
+))]
+use arboard::Clipboard;
 use bevy::{
     app::{App, Last, Plugin, PostUpdate, PreStartup, PreUpdate},
     asset::{load_internal_asset, AssetEvent, Assets, Handle},
@@ -93,12 +97,15 @@ use bevy::{
     window::{PrimaryWindow, Window},
 };
 use std::borrow::Cow;
-
-#[cfg(all(feature = "manage_clipboard", not(any(target_arch = "wasm32", target_os = "android"))))]
-use arboard::Clipboard;
-#[cfg(all(feature = "manage_clipboard", not(any(target_arch = "wasm32", target_os = "android"))))]
+#[cfg(all(
+    feature = "manage_clipboard",
+    not(any(target_arch = "wasm32", target_os = "android"))
+))]
 use std::cell::{RefCell, RefMut};
-#[cfg(all(feature = "manage_clipboard", not(any(target_arch = "wasm32", target_os = "android"))))]
+#[cfg(all(
+    feature = "manage_clipboard",
+    not(any(target_arch = "wasm32", target_os = "android"))
+))]
 use thread_local::ThreadLocal;
 
 /// Adds all Egui resources and render graph nodes.
@@ -580,10 +587,8 @@ impl Plugin for EguiPlugin {
         let world = &mut app.world;
         world.init_resource::<EguiSettings>();
         world.init_resource::<EguiManagedTextures>();
-
         #[cfg(all(feature = "manage_clipboard", not(target_os = "android")))]
         world.init_resource::<EguiClipboard>();
-
         world.init_resource::<EguiUserTextures>();
         world.init_resource::<EguiMousePosition>();
         world.insert_resource(TouchId::default());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,8 +65,7 @@ use crate::{
     render_systems::{EguiTransforms, ExtractedEguiManagedTextures},
     systems::*,
 };
-#[cfg(all(feature = "manage_clipboard", not(target_arch = "wasm32")))]
-use arboard::Clipboard;
+
 use bevy::{
     app::{App, Last, Plugin, PostUpdate, PreStartup, PreUpdate},
     asset::{load_internal_asset, AssetEvent, Assets, Handle},
@@ -94,9 +93,12 @@ use bevy::{
     window::{PrimaryWindow, Window},
 };
 use std::borrow::Cow;
-#[cfg(all(feature = "manage_clipboard", not(target_arch = "wasm32")))]
+
+#[cfg(all(feature = "manage_clipboard", not(any(target_arch = "wasm32", target_os = "android"))))]
+use arboard::Clipboard;
+#[cfg(all(feature = "manage_clipboard", not(any(target_arch = "wasm32", target_os = "android"))))]
 use std::cell::{RefCell, RefMut};
-#[cfg(all(feature = "manage_clipboard", not(target_arch = "wasm32")))]
+#[cfg(all(feature = "manage_clipboard", not(any(target_arch = "wasm32", target_os = "android"))))]
 use thread_local::ThreadLocal;
 
 /// Adds all Egui resources and render graph nodes.
@@ -189,7 +191,7 @@ pub struct EguiInput(pub egui::RawInput);
 /// A resource for accessing clipboard.
 ///
 /// The resource is available only if `manage_clipboard` feature is enabled.
-#[cfg(feature = "manage_clipboard")]
+#[cfg(all(feature = "manage_clipboard", not(target_os = "android")))]
 #[derive(Default, Resource)]
 pub struct EguiClipboard {
     #[cfg(not(target_arch = "wasm32"))]
@@ -198,7 +200,7 @@ pub struct EguiClipboard {
     clipboard: String,
 }
 
-#[cfg(feature = "manage_clipboard")]
+#[cfg(all(feature = "manage_clipboard", not(target_os = "android")))]
 impl EguiClipboard {
     /// Sets clipboard contents.
     pub fn set_contents(&mut self, contents: &str) {
@@ -578,8 +580,10 @@ impl Plugin for EguiPlugin {
         let world = &mut app.world;
         world.init_resource::<EguiSettings>();
         world.init_resource::<EguiManagedTextures>();
-        #[cfg(feature = "manage_clipboard")]
+
+        #[cfg(all(feature = "manage_clipboard", not(target_os = "android")))]
         world.init_resource::<EguiClipboard>();
+
         world.init_resource::<EguiUserTextures>();
         world.init_resource::<EguiMousePosition>();
         world.insert_resource(TouchId::default());

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -61,7 +61,7 @@ pub struct TouchId(pub Option<u64>);
 #[allow(missing_docs)]
 #[derive(SystemParam)]
 pub struct InputResources<'w, 's> {
-    #[cfg(feature = "manage_clipboard")]
+    #[cfg(all(feature = "manage_clipboard", not(target_os = "android")))]
     pub egui_clipboard: Res<'w, crate::EguiClipboard>,
     pub keyboard_input: Res<'w, Input<KeyCode>>,
     #[system_param(ignore)]
@@ -259,7 +259,7 @@ pub fn process_input_system(
 
                 // We also check that it's an `ButtonState::Pressed` event, as we don't want to
                 // copy, cut or paste on the key release.
-                #[cfg(feature = "manage_clipboard")]
+                #[cfg(all(feature = "manage_clipboard", not(target_os = "android")))]
                 if command && pressed {
                     match key {
                         egui::Key::C => {
@@ -416,7 +416,8 @@ pub fn process_output_system(
         EguiSettings,
     >,
     mut contexts: Query<EguiContextQuery>,
-    #[cfg(feature = "manage_clipboard")] mut egui_clipboard: ResMut<crate::EguiClipboard>,
+    #[cfg(all(feature = "manage_clipboard", not(target_os = "android")))]
+    mut egui_clipboard: ResMut<crate::EguiClipboard>,
     mut event: EventWriter<RequestRedraw>,
     #[cfg(windows)] mut last_cursor_icon: Local<bevy::utils::HashMap<Entity, egui::CursorIcon>>,
 ) {
@@ -437,7 +438,7 @@ pub fn process_output_system(
 
         context.egui_output.platform_output = platform_output.clone();
 
-        #[cfg(feature = "manage_clipboard")]
+        #[cfg(all(feature = "manage_clipboard", not(target_os = "android")))]
         if !platform_output.copied_text.is_empty() {
             egui_clipboard.set_contents(&platform_output.copied_text);
         }


### PR DESCRIPTION
Closes #198 (and the duplicate I was about to make :0).

arboard dependency does not support android and fails too build for said platform,

this pr modifies the existing target_arch checks too include target_os = "android" check