### PR TITLE
Fix @ on AZERTY on wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ webbrowser = { version = "0.8.2", optional = true }
 arboard = { version = "3.2.0", optional = true }
 thread_local = { version = "1.1.0", optional = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-sys = { version = "0.3.63", features = ["Navigator"] }
+
 [dev-dependencies]
 version-sync = "0.9.4"
 bevy = { version = "0.13", default-features = false, features = [


### PR DESCRIPTION
Another attempt to https://github.com/mvlabat/bevy_egui/pull/181

This PR retrieves the user agent for better platform detection.

Not much tested, it seemed on wasm I was receiving physical keys, so my next step is to check how it's going with bevy 0.13