### PR TITLE
Fix text editing keybinds

### DIFF
--- a/src/systems.rs
+++ b/src/systems.rs
@@ -163,7 +163,7 @@ pub fn process_input_system(
         win,
     } = *input_resources.modifier_keys_state;
     let mac_cmd = if *context_params.is_macos { win } else { false };
-    let command = if !*context_params.is_macos { win } else { ctrl };
+    let command = if *context_params.is_macos { win } else { ctrl };
 
     let modifiers = egui::Modifiers {
         alt,
@@ -266,7 +266,7 @@ pub fn process_input_system(
         }
     }
 
-    if !command || !*context_params.is_macos && ctrl && alt {
+    if !command && !win || !*context_params.is_macos && ctrl && alt {
         for event in input_events.ev_received_character.read() {
             if event.char.matches(char::is_control).count() == 0 {
                 let mut context = context_params.contexts.get_mut(event.window).unwrap();


### PR DESCRIPTION
Copy, paste, cut, undo, redo and maybe others were bound to WIN instead of CTRL outside of macOS, which was wrong. It broke after updating to the latest Bevy. This pr binds them back to CTRL.

I also have to prevent text input when win is pressed because the command check doesn't work by itself anymore.

I don't have a mac available right now, but I assume it was broken for macOS too, because copy is CMD-C on macOS. The egui docs also tell you to use the same thing for command as mac_cmd.