### PR TITLE
Better error on Web when missing web_sys_unstable_apis

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
     target_arch = "wasm32",
     not(web_sys_unstable_apis)
 ))]
-compile_error!("bevy_egui uses unstable APIs to support clipboard on web, please add `--cfg=web_sys_unstable_apis` in your rustflags or disable the `bevy_egui::manage_clipboard` feature.");
+compile_error!(include_str!("../static/error_web_sys_unstable_apis.txt"));
 
 /// Egui render node.
 #[cfg(feature = "render")]

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -72,7 +72,11 @@ pub struct ModifierKeysState {
 #[allow(missing_docs)]
 #[derive(SystemParam)]
 pub struct InputResources<'w, 's> {
-    #[cfg(all(feature = "manage_clipboard", not(target_os = "android")))]
+    #[cfg(all(
+        feature = "manage_clipboard",
+        not(target_os = "android"),
+        not(all(target_arch = "wasm32", not(web_sys_unstable_apis)))
+    ))]
     pub egui_clipboard: ResMut<'w, crate::EguiClipboard>,
     pub modifier_keys_state: Local<'s, ModifierKeysState>,
     #[system_param(ignore)]
@@ -328,7 +332,11 @@ pub fn process_input_system(
             }
         }
 
-        #[cfg(all(feature = "manage_clipboard", target_arch = "wasm32"))]
+        #[cfg(all(
+            feature = "manage_clipboard",
+            target_arch = "wasm32",
+            web_sys_unstable_apis
+        ))]
         while let Some(event) = input_resources.egui_clipboard.try_receive_clipboard_event() {
             match event {
                 crate::web_clipboard::WebClipboardEvent::Copy => {
@@ -505,7 +513,11 @@ pub fn process_output_system(
 
         context.egui_output.platform_output = platform_output.clone();
 
-        #[cfg(all(feature = "manage_clipboard", not(target_os = "android")))]
+        #[cfg(all(
+            feature = "manage_clipboard",
+            not(target_os = "android"),
+            not(all(target_arch = "wasm32", not(web_sys_unstable_apis)))
+        ))]
         if !platform_output.copied_text.is_empty() {
             egui_clipboard.set_contents(&platform_output.copied_text);
         }

--- a/static/error_web_sys_unstable_apis.txt
+++ b/static/error_web_sys_unstable_apis.txt
@@ -1,0 +1,6 @@
+bevy_egui uses unstable APIs to support clipboard on web.
+
+Please add `--cfg=web_sys_unstable_apis` to your rustflags or disable the `bevy_egui::manage_clipboard` feature.
+
+More Info: https://rustwasm.github.io/wasm-bindgen/web-sys/unstable-apis.html
+  


### PR DESCRIPTION
<details><summary>Before:</summary>
<p>

![image](https://github.com/mvlabat/bevy_egui/assets/2290685/83df43ab-7834-49bc-9841-0763633ee55a)

</p>
</details> 

<details><summary>After:</summary>
<p>

![image](https://github.com/mvlabat/bevy_egui/assets/2290685/5489d5c5-4565-462c-9270-167d75149df9)

</p>
</details> 



