### PR TITLE
update to egui 0.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ required-features = ["render"]
 
 [dependencies]
 bevy = { version = "0.13", default-features = false, features = ["bevy_asset"] }
-egui = { version = "0.26", default-features = false, features = ["bytemuck"] }
+egui = { version = "0.27", default-features = false, features = ["bytemuck"] }
 webbrowser = { version = "0.8.2", optional = true }
 
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]


### PR DESCRIPTION
Pretty uneventful update, here's a list to the breaking changes [egui/CHANGELOG.md](https://github.com/emilk/egui/blob/master/CHANGELOG.md#%EF%B8%8F-breaking)

> Response::clicked* and Response::dragged* may lock the Context, so don't call it from a Context-locking closure.

I don't think this is done in `bevy_egui` so that should be fine.