### PR TITLE
Request Redraw only if really needed. Fixes #277

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,6 +288,13 @@ pub struct EguiRenderOutput {
     pub textures_delta: egui::TexturesDelta,
 }
 
+impl EguiRenderOutput {
+    /// Returns `true` if the output has no Egui shapes and no textures delta
+    pub fn is_empty(&self) -> bool {
+        self.paint_jobs.is_empty() && self.textures_delta.is_empty()
+    }
+}
+
 /// Is used for storing Egui output.
 #[derive(Component, Clone, Default)]
 pub struct EguiOutput {

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -532,7 +532,10 @@ pub fn process_output_system(
         #[cfg(not(windows))]
         set_icon();
 
-        if ctx.has_requested_repaint() {
+        let needs_repaint = !context.render_output.paint_jobs.is_empty()
+            && !context.render_output.textures_delta.is_empty();
+
+        if ctx.has_requested_repaint() && needs_repaint {
             event.send(RequestRedraw);
         }
 


### PR DESCRIPTION
Hello,

I had this problem that I described at this issue:

- #277

where it is a blocker for my use case that `bevy_egui` sends `RequestRedraw` events, even when I'm not painting any EGUI window.

So, this PR fixes the `process_output_system` so that it doesn't emit that event when nothing is being painted.

It will keep working as usual when EGUI is painting.

----

On another note:

I'm not sure that `RequestRedraw` is really needed. If the `UpdateMode` of the Bevy's `WinitSettings` resource is `UpdateMode::Continuous`, Bevy will redraw anyway. If it is `UpdateMode::Reactive` or `UpdateMode::ReactiveLowPower`, both of them should answer to Window events, like moving the cursor ([see here in bevy_winit](https://github.com/bevyengine/bevy/blob/c593ee1055047a64501efa5de5885c9d85547af3/crates/bevy_winit/src/lib.rs#L387-L404))

However, I'm not removing it in this PR to be cautious and not reintroduce previous bugs like 
- #240
- #239
- #176