### PR TITLE
fix light in `render_to_image_widget` example

### DIFF
--- a/examples/render_to_image_widget.rs
+++ b/examples/render_to_image_widget.rs
@@ -91,12 +91,14 @@ fn setup(
         .insert(PreviewPassCube)
         .insert(preview_pass_layer);
 
-    // Light
-    // NOTE: Currently lights are shared between passes - see https://github.com/bevyengine/bevy/issues/3462
-    commands.spawn(PointLightBundle {
-        transform: Transform::from_translation(Vec3::new(0.0, 0.0, 10.0)),
-        ..default()
-    });
+    // The same light is reused for both passes,
+    // you can specify different lights for preview and main pass by setting appropriate RenderLayers.
+    commands
+        .spawn(PointLightBundle {
+            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 10.0)),
+            ..default()
+        })
+        .insert(RenderLayers::all());
 
     commands
         .spawn(Camera3dBundle {


### PR DESCRIPTION
Issue https://github.com/bevyengine/bevy/issues/3462 has been fixed. So since Bevy 0.13, render lights can be specified per RenderLayer.

So our example needs to be updated, because right now render pass does not have any light at all.

I've decided to reuse the same light by specifying `RenderLayers::all()`, although adding a separate one (with preview_pass_layer and without) is also fine.