### PR TITLE
Simple fix to clear wrong input state

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -11,8 +11,9 @@ fn main() {
         .run();
 }
 
-fn ui_example_system(mut contexts: EguiContexts) {
+fn ui_example_system(mut contexts: EguiContexts, mut text: Local<String>) {
     egui::Window::new("Hello").show(contexts.ctx_mut(), |ui| {
         ui.label("world");
+        ui.text_edit_singleline(&mut *text);
     });
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -119,6 +119,10 @@ pub fn process_input_system(
         }
     });
 
+    if !context_params.contexts.iter().any(|c| c.window.focused) {
+        *input_resources.modifier_keys_state = Default::default();
+    }
+
     let mut keyboard_input_events = Vec::new();
     for event in input_events.ev_keyboard_input.read() {
         // Copy the events as we might want to pass them to an Egui context later.


### PR DESCRIPTION
Kind of solves #296

This fix is pretty stupid though. Maybe there's something better we can do?

*edit:

I tried to make the reset happen not as often and only when we lose focus of <ALL> windows. I hope that this will rule out any unexpected state resets.