### PR TITLE
Paint callback support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ render = ["bevy/bevy_render"]
 serde = ["egui/serde"]
 
 [[example]]
+name = "paint_callback"
+required-features = ["render"]
+[[example]]
 name = "render_to_image_widget"
 required-features = ["render"]
 [[example]]
@@ -60,6 +63,7 @@ bevy = { version = "0.14.0", default-features = false, features = [
     "tonemapping_luts",
     "webgl2",
 ] }
+egui = { version = "0.28", default-features = false, features = ["bytemuck"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 winit = "0.30"

--- a/examples/paint_callback.rs
+++ b/examples/paint_callback.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use bevy::{
     asset::{embedded_asset, AssetPath},
     prelude::*,
@@ -17,6 +15,7 @@ use bevy_egui::{
     egui_node::{EguiBevyPaintCallback, EguiBevyPaintCallbackImpl, EguiPipelineKey},
     EguiContexts, EguiPlugin,
 };
+use std::path::Path;
 
 fn main() {
     App::new()

--- a/examples/paint_callback.rs
+++ b/examples/paint_callback.rs
@@ -1,0 +1,173 @@
+use std::path::Path;
+
+use bevy::{
+    asset::{embedded_asset, AssetPath},
+    prelude::*,
+    render::{
+        mesh::PrimitiveTopology,
+        render_resource::{
+            BlendState, CachedRenderPipelineId, ColorTargetState, ColorWrites, FragmentState,
+            MultisampleState, PipelineCache, PolygonMode, PrimitiveState, RenderPipelineDescriptor,
+            SpecializedRenderPipeline, SpecializedRenderPipelines,
+        },
+        RenderApp,
+    },
+};
+use bevy_egui::{
+    egui_node::{EguiBevyPaintCallback, EguiBevyPaintCallbackImpl, EguiPipelineKey},
+    EguiContexts, EguiPlugin,
+};
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, EguiPlugin, CustomPipelinePlugin))
+        .add_systems(Update, ui_example_system)
+        .run();
+}
+
+struct CustomPipelinePlugin;
+
+impl Plugin for CustomPipelinePlugin {
+    fn build(&self, app: &mut App) {
+        embedded_asset!(app, "examples/", "paint_callback.wgsl");
+        app.get_sub_app_mut(RenderApp)
+            .unwrap()
+            .insert_resource(SpecializedRenderPipelines::<CustomPipeline>::default())
+            .init_resource::<CustomPipeline>();
+    }
+}
+
+struct CustomPaintCallback;
+
+#[derive(Component)]
+struct CustomPaintPipelineIdComp {
+    pipeline_id: CachedRenderPipelineId,
+}
+
+impl EguiBevyPaintCallbackImpl for CustomPaintCallback {
+    fn update(
+        &self,
+        _info: egui::PaintCallbackInfo,
+        window_entity: Entity,
+        key: EguiPipelineKey,
+        world: &mut World,
+    ) {
+        let pipeline_id =
+            world.resource_scope(
+                |world,
+                 mut specialized_custom_pipelines: Mut<
+                    SpecializedRenderPipelines<CustomPipeline>,
+                >| {
+                    let specialized_pipeline = world.get_resource().unwrap();
+                    let pipeline_cache = world.get_resource().unwrap();
+
+                    let pipeline_id = specialized_custom_pipelines.specialize(
+                        pipeline_cache,
+                        specialized_pipeline,
+                        key,
+                    );
+
+                    world
+                        .entity_mut(window_entity)
+                        .insert(CustomPaintPipelineIdComp { pipeline_id });
+                    pipeline_id
+                },
+            );
+
+        let mut pipeline_cache = world.get_resource_mut::<PipelineCache>().unwrap();
+        pipeline_cache.block_on_render_pipeline(pipeline_id);
+    }
+
+    fn render<'pass>(
+        &self,
+        _info: egui::PaintCallbackInfo,
+        render_pass: &mut bevy::render::render_phase::TrackedRenderPass<'pass>,
+        window_entity: Entity,
+        _key: EguiPipelineKey,
+        world: &'pass World,
+    ) {
+        let Some(pipeline) = world
+            .get_entity(window_entity)
+            .and_then(|entity| entity.get::<CustomPaintPipelineIdComp>())
+            .and_then(|comp| {
+                world
+                    .get_resource::<PipelineCache>()
+                    .and_then(|cache| cache.get_render_pipeline(comp.pipeline_id))
+            })
+        else {
+            return;
+        };
+
+        render_pass.set_render_pipeline(pipeline);
+        render_pass.draw(0..3, 0..1);
+    }
+}
+
+#[derive(Debug, Resource)]
+struct CustomPipeline {
+    shader: Handle<Shader>,
+}
+
+impl FromWorld for CustomPipeline {
+    fn from_world(world: &mut World) -> Self {
+        let shader = world.resource::<AssetServer>().load(
+            AssetPath::from_path(Path::new("paint_callback/paint_callback.wgsl"))
+                .with_source("embedded"),
+        );
+
+        Self { shader }
+    }
+}
+
+impl SpecializedRenderPipeline for CustomPipeline {
+    type Key = EguiPipelineKey;
+
+    fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
+        RenderPipelineDescriptor {
+            label: Some("custom pipeline".into()),
+            layout: vec![],
+            push_constant_ranges: Vec::new(),
+            vertex: bevy::render::render_resource::VertexState {
+                shader: self.shader.clone(),
+                shader_defs: vec![],
+                entry_point: "vertex".into(),
+                buffers: vec![],
+            },
+            primitive: PrimitiveState {
+                topology: PrimitiveTopology::TriangleStrip,
+                strip_index_format: None,
+                front_face: bevy::render::render_resource::FrontFace::Ccw,
+                cull_mode: None,
+                unclipped_depth: false,
+                polygon_mode: PolygonMode::Fill,
+                conservative: false,
+            },
+            depth_stencil: None,
+            multisample: MultisampleState::default(),
+            fragment: Some(FragmentState {
+                shader: self.shader.clone(),
+                shader_defs: vec![],
+                entry_point: "fragment".into(),
+                targets: vec![Some(ColorTargetState {
+                    format: key.texture_format,
+                    blend: Some(BlendState::ALPHA_BLENDING),
+                    write_mask: ColorWrites::ALL,
+                })],
+            }),
+        }
+    }
+}
+
+fn ui_example_system(mut ctx: EguiContexts) {
+    for id in 0..4 {
+        egui::Window::new(id.to_string()).show(ctx.ctx_mut(), |ui| {
+            let (resp, painter) =
+                ui.allocate_painter(egui::Vec2 { x: 200., y: 200. }, egui::Sense::hover());
+
+            painter.add(EguiBevyPaintCallback::new_paint_callback(
+                resp.rect,
+                CustomPaintCallback,
+            ));
+        });
+    }
+}

--- a/examples/paint_callback.wgsl
+++ b/examples/paint_callback.wgsl
@@ -1,0 +1,21 @@
+const POS = array(
+    vec2f(0, -1) * 0.5,
+    vec2f(1, 1) * 0.5,
+    vec2f(-1, 1) * 0.5,
+);
+
+@vertex
+fn vertex(@builtin(vertex_index) vertex_index: u32) -> @builtin(position) vec4f {
+    if vertex_index == 0 {
+        return vec4f(POS[0], 0, 1);
+    } else if vertex_index == 1 {
+        return vec4f(POS[1], 0, 1);
+    } else {
+        return vec4f(POS[2], 0, 1);
+    }
+}
+
+@fragment
+fn fragment() -> @location(0) vec4f {
+    return vec4f(1, 1, 0, 1);
+}

--- a/src/egui_node.rs
+++ b/src/egui_node.rs
@@ -10,6 +10,7 @@ use bevy::{
     render::{
         render_asset::RenderAssetUsages,
         render_graph::{Node, NodeRunError, RenderGraphContext},
+        render_phase::TrackedRenderPass,
         render_resource::{
             BindGroupLayout, BindGroupLayoutEntry, BindingType, BlendComponent, BlendFactor,
             BlendOperation, BlendState, Buffer, BufferAddress, BufferBindingType, BufferDescriptor,
@@ -22,7 +23,7 @@ use bevy::{
         },
         renderer::{RenderContext, RenderDevice, RenderQueue},
         texture::{Image, ImageAddressMode, ImageFilterMode, ImageSampler, ImageSamplerDescriptor},
-        view::ExtractedWindows,
+        view::{ExtractedWindow, ExtractedWindows},
     },
 };
 use bytemuck::cast_slice;
@@ -94,6 +95,15 @@ pub struct EguiPipelineKey {
     pub texture_format: TextureFormat,
 }
 
+impl EguiPipelineKey {
+    /// Extracts target texture format in egui renderpass
+    pub fn from_extracted_window(window: &ExtractedWindow) -> Option<Self> {
+        Some(Self {
+            texture_format: window.swap_chain_texture_format?.add_srgb_suffix(),
+        })
+    }
+}
+
 impl SpecializedRenderPipeline for EguiPipeline {
     type Key = EguiPipelineKey;
 
@@ -150,11 +160,25 @@ impl SpecializedRenderPipeline for EguiPipeline {
     }
 }
 
-#[derive(Debug)]
 struct DrawCommand {
+    clip_rect: egui::Rect,
+    primitive: DrawPrimitive,
+}
+
+enum DrawPrimitive {
+    Egui(EguiDraw),
+    PaintCallback(PaintCallbackDraw),
+}
+
+struct PaintCallbackDraw {
+    callback: std::sync::Arc<EguiBevyPaintCallback>,
+    rect: egui::Rect,
+}
+
+#[derive(Debug)]
+struct EguiDraw {
     vertices_count: usize,
     egui_texture: EguiTextureId,
-    clipping_zone: (u32, u32, u32, u32), // x, y, w, h
 }
 
 /// Egui render node.
@@ -167,6 +191,8 @@ pub struct EguiNode {
     index_buffer_capacity: usize,
     index_buffer: Option<Buffer>,
     draw_commands: Vec<DrawCommand>,
+    postponed_updates: Vec<(egui::Rect, PaintCallbackDraw)>,
+    pixels_per_point: f32,
 }
 
 impl EguiNode {
@@ -181,12 +207,22 @@ impl EguiNode {
             index_data: Vec::new(),
             index_buffer_capacity: 0,
             index_buffer: None,
+            postponed_updates: Vec::new(),
+            pixels_per_point: 1.,
         }
     }
 }
 
 impl Node for EguiNode {
     fn update(&mut self, world: &mut World) {
+        let Some(key) = world
+            .get_resource::<ExtractedWindows>()
+            .and_then(|windows| windows.windows.get(&self.window_entity))
+            .and_then(EguiPipelineKey::from_extracted_window)
+        else {
+            return;
+        };
+
         let mut window_sizes = world.query::<(&WindowSize, &mut EguiRenderOutput)>();
 
         let Ok((window_size, mut render_output)) = window_sizes.get_mut(world, self.window_entity)
@@ -200,7 +236,7 @@ impl Node for EguiNode {
 
         let render_device = world.get_resource::<RenderDevice>().unwrap();
 
-        let scale_factor = window_size.scale_factor * egui_settings.scale_factor;
+        self.pixels_per_point = window_size.scale_factor * egui_settings.scale_factor;
         if window_size.physical_width == 0.0 || window_size.physical_height == 0.0 {
             return;
         }
@@ -210,33 +246,51 @@ impl Node for EguiNode {
         self.draw_commands.clear();
         self.vertex_data.clear();
         self.index_data.clear();
+        self.postponed_updates.clear();
 
         for egui::epaint::ClippedPrimitive {
             clip_rect,
             primitive,
-        } in &paint_jobs
+        } in paint_jobs
         {
-            let mesh = match primitive {
-                egui::epaint::Primitive::Mesh(mesh) => mesh,
-                egui::epaint::Primitive::Callback(_) => {
-                    unimplemented!("Paint callbacks aren't supported")
-                }
-            };
+            let clipping_zone = ClippingZone::new(&clip_rect, self.pixels_per_point);
 
-            let (x, y, w, h) = (
-                (clip_rect.min.x * scale_factor).round() as u32,
-                (clip_rect.min.y * scale_factor).round() as u32,
-                (clip_rect.width() * scale_factor).round() as u32,
-                (clip_rect.height() * scale_factor).round() as u32,
-            );
-
-            if w < 1
-                || h < 1
-                || x >= window_size.physical_width as u32
-                || y >= window_size.physical_height as u32
+            if clipping_zone
+                .valid_scrissor_rect(
+                    window_size.physical_width as u32,
+                    window_size.physical_height as u32,
+                )
+                .is_none()
             {
                 continue;
             }
+
+            let mesh = match primitive {
+                egui::epaint::Primitive::Mesh(mesh) => mesh,
+                egui::epaint::Primitive::Callback(paint_callback) => {
+                    let Ok(callback) = paint_callback.callback.downcast::<EguiBevyPaintCallback>()
+                    else {
+                        unimplemented!("Unsupported egui paint callback type");
+                    };
+
+                    self.postponed_updates.push((
+                        clip_rect,
+                        PaintCallbackDraw {
+                            callback: callback.clone(),
+                            rect: paint_callback.rect,
+                        },
+                    ));
+
+                    self.draw_commands.push(DrawCommand {
+                        primitive: DrawPrimitive::PaintCallback(PaintCallbackDraw {
+                            callback,
+                            rect: paint_callback.rect,
+                        }),
+                        clip_rect,
+                    });
+                    continue;
+                }
+            };
 
             self.vertex_data
                 .extend_from_slice(cast_slice::<_, u8>(mesh.vertices.as_slice()));
@@ -254,17 +308,12 @@ impl Node for EguiNode {
                 egui::TextureId::User(id) => EguiTextureId::User(id),
             };
 
-            let x_viewport_clamp = (x + w).saturating_sub(window_size.physical_width as u32);
-            let y_viewport_clamp = (y + h).saturating_sub(window_size.physical_height as u32);
             self.draw_commands.push(DrawCommand {
-                vertices_count: mesh.indices.len(),
-                egui_texture: texture_handle,
-                clipping_zone: (
-                    x,
-                    y,
-                    w.saturating_sub(x_viewport_clamp).max(1),
-                    h.saturating_sub(y_viewport_clamp).max(1),
-                ),
+                primitive: DrawPrimitive::Egui(EguiDraw {
+                    vertices_count: mesh.indices.len(),
+                    egui_texture: texture_handle,
+                }),
+                clip_rect,
             });
         }
 
@@ -293,6 +342,22 @@ impl Node for EguiNode {
                 usage: BufferUsages::COPY_DST | BufferUsages::INDEX,
                 mapped_at_creation: false,
             }));
+        }
+
+        for (clip_rect, command) in self.postponed_updates.drain(..) {
+            let info = egui::PaintCallbackInfo {
+                viewport: command.rect,
+                clip_rect,
+                pixels_per_point: self.pixels_per_point,
+                screen_size_px: [
+                    window_size.physical_width as u32,
+                    window_size.physical_height as u32,
+                ],
+            };
+            command
+                .callback
+                .cb()
+                .update(info, self.window_entity, key, world);
         }
     }
 
@@ -335,7 +400,9 @@ impl Node for EguiNode {
 
         let egui_transforms = world.get_resource::<EguiTransforms>().unwrap();
 
-        let mut render_pass =
+        let device = world.get_resource::<RenderDevice>().unwrap();
+
+        let render_pass =
             render_context
                 .command_encoder()
                 .begin_render_pass(&RenderPassDescriptor {
@@ -352,6 +419,11 @@ impl Node for EguiNode {
                     timestamp_writes: None,
                     occlusion_query_set: None,
                 });
+        let mut render_pass = TrackedRenderPass::new(device, render_pass);
+
+        let Some(key) = EguiPipelineKey::from_extracted_window(extracted_window) else {
+            return Ok(());
+        };
 
         let Some(pipeline_id) = egui_pipelines.get(&extracted_window.entity) else {
             return Ok(());
@@ -360,53 +432,109 @@ impl Node for EguiNode {
             return Ok(());
         };
 
-        render_pass.set_pipeline(pipeline);
-        render_pass.set_vertex_buffer(0, *self.vertex_buffer.as_ref().unwrap().slice(..));
-        render_pass.set_index_buffer(
-            *self.index_buffer.as_ref().unwrap().slice(..),
-            IndexFormat::Uint32,
-        );
-
         let transform_buffer_offset = egui_transforms.offsets[&self.window_entity];
         let transform_buffer_bind_group = &egui_transforms.bind_group.as_ref().unwrap().1;
-        render_pass.set_bind_group(0, transform_buffer_bind_group, &[transform_buffer_offset]);
+
+        let mut requires_reset = true;
 
         let mut vertex_offset: u32 = 0;
         for draw_command in &self.draw_commands {
-            if draw_command.clipping_zone.0 < extracted_window.physical_width
-                && draw_command.clipping_zone.1 < extracted_window.physical_height
-            {
-                let texture_bind_group = match bind_groups.get(&draw_command.egui_texture) {
-                    Some(texture_resource) => texture_resource,
-                    None => {
-                        vertex_offset += draw_command.vertices_count as u32;
-                        continue;
-                    }
-                };
-
-                render_pass.set_bind_group(1, texture_bind_group, &[]);
-
-                render_pass.set_scissor_rect(
-                    draw_command.clipping_zone.0,
-                    draw_command.clipping_zone.1,
-                    draw_command.clipping_zone.2.min(
-                        extracted_window
-                            .physical_width
-                            .saturating_sub(draw_command.clipping_zone.0),
-                    ),
-                    draw_command.clipping_zone.3.min(
-                        extracted_window
-                            .physical_height
-                            .saturating_sub(draw_command.clipping_zone.1),
-                    ),
+            if requires_reset {
+                render_pass.set_viewport(
+                    0.,
+                    0.,
+                    extracted_window.physical_width as f32,
+                    extracted_window.physical_height as f32,
+                    0.,
+                    1.,
                 );
-
-                render_pass.draw_indexed(
-                    vertex_offset..(vertex_offset + draw_command.vertices_count as u32),
+                render_pass.set_render_pipeline(pipeline);
+                render_pass.set_bind_group(
                     0,
-                    0..1,
+                    transform_buffer_bind_group,
+                    &[transform_buffer_offset],
                 );
-                vertex_offset += draw_command.vertices_count as u32;
+
+                requires_reset = false;
+            }
+
+            let Some(scrissor_rect) =
+                ClippingZone::new(&draw_command.clip_rect, self.pixels_per_point)
+                    .valid_scrissor_rect(
+                        extracted_window.physical_width,
+                        extracted_window.physical_height,
+                    )
+            else {
+                continue;
+            };
+
+            render_pass.set_scissor_rect(
+                scrissor_rect.x,
+                scrissor_rect.y,
+                scrissor_rect.w,
+                scrissor_rect.h,
+            );
+
+            match &draw_command.primitive {
+                DrawPrimitive::Egui(command) => {
+                    let texture_bind_group = match bind_groups.get(&command.egui_texture) {
+                        Some(texture_resource) => texture_resource,
+                        None => {
+                            vertex_offset += command.vertices_count as u32;
+                            continue;
+                        }
+                    };
+
+                    render_pass.set_bind_group(1, texture_bind_group, &[]);
+
+                    render_pass
+                        .set_vertex_buffer(0, self.vertex_buffer.as_ref().unwrap().slice(..));
+                    render_pass.set_index_buffer(
+                        self.index_buffer.as_ref().unwrap().slice(..),
+                        0,
+                        IndexFormat::Uint32,
+                    );
+
+                    render_pass.draw_indexed(
+                        vertex_offset..(vertex_offset + command.vertices_count as u32),
+                        0,
+                        0..1,
+                    );
+
+                    vertex_offset += command.vertices_count as u32;
+                }
+                DrawPrimitive::PaintCallback(command) => {
+                    let info = egui::PaintCallbackInfo {
+                        viewport: command.rect,
+                        clip_rect: draw_command.clip_rect,
+                        pixels_per_point: self.pixels_per_point,
+                        screen_size_px: [
+                            extracted_window.physical_width,
+                            extracted_window.physical_height,
+                        ],
+                    };
+
+                    let viewport = info.viewport_in_pixels();
+                    if viewport.width_px > 0 && viewport.height_px > 0 {
+                        requires_reset = true;
+                        render_pass.set_viewport(
+                            viewport.left_px as f32,
+                            viewport.top_px as f32,
+                            viewport.width_px as f32,
+                            viewport.height_px as f32,
+                            0.,
+                            1.,
+                        );
+
+                        command.callback.cb().render(
+                            info,
+                            &mut render_pass,
+                            self.window_entity,
+                            key,
+                            world,
+                        );
+                    }
+                }
             }
         }
 
@@ -478,4 +606,94 @@ pub(crate) fn texture_options_as_sampler_descriptor(
         address_mode_v: address_mode,
         ..Default::default()
     }
+}
+
+#[derive(Debug)]
+struct ClippingZone {
+    x: u32,
+    y: u32,
+    w: u32,
+    h: u32,
+}
+impl ClippingZone {
+    fn new(clip_rect: &egui::Rect, pixels_per_point: f32) -> ClippingZone {
+        ClippingZone {
+            x: (clip_rect.min.x * pixels_per_point).round() as u32,
+            y: (clip_rect.min.y * pixels_per_point).round() as u32,
+            w: (clip_rect.width() * pixels_per_point).round() as u32,
+            h: (clip_rect.height() * pixels_per_point).round() as u32,
+        }
+    }
+
+    fn valid_scrissor_rect(&self, physical_width: u32, physical_height: u32) -> Option<Self> {
+        let x_viewport_clamp = (self.x + self.w).saturating_sub(physical_width as u32);
+        let y_viewport_clamp = (self.y + self.h).saturating_sub(physical_height as u32);
+
+        let scrissor = Self {
+            x: self.x,
+            y: self.y,
+            w: self.w.saturating_sub(x_viewport_clamp),
+            h: self.h.saturating_sub(y_viewport_clamp),
+        };
+
+        if self.w < 1
+            || self.h < 1
+            || self.x >= physical_width as u32
+            || self.y >= physical_height as u32
+        {
+            return None;
+        }
+
+        Some(scrissor)
+    }
+}
+
+/// Callback to execute custom 'wgpu' rendering inside [`EguiNode`] render graph node.
+///
+/// Rendering can be implemented using for example:
+/// * native wgpu rendering libraries,
+/// * or with [`bevy::render::render_phase`] approach.
+pub struct EguiBevyPaintCallback(Box<dyn EguiBevyPaintCallbackImpl>);
+
+impl EguiBevyPaintCallback {
+    /// Creates a new [`egui::epaint::PaintCallback`] from a callback trait instance.
+    pub fn new_paint_callback<T>(rect: egui::Rect, callback: T) -> egui::epaint::PaintCallback
+    where
+        T: EguiBevyPaintCallbackImpl + 'static,
+    {
+        let callback = Self(Box::new(callback));
+        egui::epaint::PaintCallback {
+            rect,
+            callback: std::sync::Arc::new(callback),
+        }
+    }
+
+    fn cb(&self) -> &Box<dyn EguiBevyPaintCallbackImpl> {
+        &self.0
+    }
+}
+
+/// Callback that executes custom rendering logic
+pub trait EguiBevyPaintCallbackImpl: Send + Sync {
+    /// Paint callback will be rendered in near future, all data must be finalized for render step
+    fn update(
+        &self,
+        info: egui::PaintCallbackInfo,
+        window_entity: Entity,
+        pipeline_key: EguiPipelineKey,
+        world: &mut World,
+    );
+
+    /// Paint callback render step
+    ///
+    /// Native wgpu RenderPass can be retrieved from [`TrackedRenderPass`] by calling
+    /// [`TrackedRenderPass::wgpu_pass`].
+    fn render<'pass>(
+        &self,
+        info: egui::PaintCallbackInfo,
+        render_pass: &mut TrackedRenderPass<'pass>,
+        window_entity: Entity,
+        pipeline_key: EguiPipelineKey,
+        world: &'pass World,
+    );
 }

--- a/src/render_systems.rs
+++ b/src/render_systems.rs
@@ -232,9 +232,7 @@ pub fn queue_pipelines_system(
     let pipelines = windows
         .iter()
         .filter_map(|(window_id, window)| {
-            let key = EguiPipelineKey {
-                texture_format: window.swap_chain_texture_format?.add_srgb_suffix(),
-            };
+            let key = EguiPipelineKey::from_extracted_window(window)?;
             let pipeline_id = pipelines.specialize(&pipeline_cache, &egui_pipeline, key);
 
             Some((*window_id, pipeline_id))


### PR DESCRIPTION
Resolves https://github.com/mvlabat/bevy_egui/issues/294

Bevy render graph nodes create render passes, paint callback can not be expanded into a render graph subgraph.

Graph node can contain custom rendering code or, for example, [Render Phase](https://docs.rs/bevy_render/latest/bevy_render/render_phase/index.html) abstraction to render multiple type of resources with multiple render pipelines in the current render pass.
This implementation supports bevy rendering logic with custom render implementation.

For now native wgpu RenderPass can not be used because of the following issue: https://github.com/bevyengine/bevy/issues/13225


