### PR TITLE
Compile time improvement: depend on subcrates

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -179,7 +179,7 @@ jobs:
           restore-keys: |
             cache-doc-cargo-${{ hashFiles('**/Cargo.toml') }}
             cache-doc-cargo
-      - run: cargo doc --all --features "bevy/x11"
+      - run: cargo doc --all --features "bevy_winit/x11"
         env:
           RUSTDOCFLAGS: -D warnings
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,8 @@ bevy = { version = "0.14.0", default-features = false, features = [
   "png",
   "bevy_pbr",
   "bevy_core_pipeline",
+  "bevy_asset",
+  "bevy_winit",
   "tonemapping_luts",
   "webgl2",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,14 @@ immutable_ctx = []
 manage_clipboard = ["arboard", "thread_local"]
 open_url = ["webbrowser"]
 default_fonts = ["egui/default_fonts"]
-render = ["bevy_render"]
+render = [
+  "bevy_render",
+  "bevy_asset",
+  "encase",
+  "bytemuck",
+  "egui/bytemuck",
+  "wgpu-types",
+]
 serde = ["egui/serde"]
 # The enabled logs will print with the info log level, to make it less cumbersome to debug in browsers.
 log_input_events = []
@@ -51,25 +58,31 @@ name = "render_egui_to_texture"
 required-features = ["render"]
 
 [dependencies]
+egui = { version = "0.29", default-features = false }
+
 bevy_app = "0.14"
-bevy_asset = "0.14"
 bevy_derive = "0.14"
 bevy_ecs = "0.14"
 bevy_input = "0.14"
 bevy_log = "0.14"
 bevy_math = "0.14"
-bevy_render = { version = "0.14", optional = true }
 bevy_reflect = "0.14"
 bevy_time = "0.14"
 bevy_utils = "0.14"
 bevy_winit = "0.14"
 bevy_window = "0.14"
-encase = "0.8"
-egui = { version = "0.29", default-features = false, features = ["bytemuck"] }
-bytemuck = "1"
-webbrowser = { version = "1.0.1", optional = true }
-wgpu-types = "0.20"
 
+# `open_url` feature
+webbrowser = { version = "1.0.1", optional = true }
+
+# `render` feature
+bytemuck = { version = "1", optional = true }
+bevy_asset = { version = "0.14", optional = true }
+bevy_render = { version = "0.14", optional = true }
+encase = { version = "0.8", optional = true }
+wgpu-types = { version = "0.20", optional = true }
+
+# `manage_clipboard` feature
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
 arboard = { version = "3.2.0", optional = true }
 thread_local = { version = "1.1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_egui"
-version = "0.30.0"
-rust-version = "1.80.0" # needed for LazyLock https://doc.rust-lang.org/stable/std/sync/struct.LazyLock.html
+version = "0.30.1"
+rust-version = "1.80.0"                                 # needed for LazyLock https://doc.rust-lang.org/stable/std/sync/struct.LazyLock.html
 authors = ["mvlabat <mvlabat@gmail.com>"]
 description = "A plugin for Egui integration into Bevy"
 license = "MIT"
@@ -20,7 +20,7 @@ immutable_ctx = []
 manage_clipboard = ["arboard", "thread_local"]
 open_url = ["webbrowser"]
 default_fonts = ["egui/default_fonts"]
-render = ["bevy/bevy_render"]
+render = ["bevy_render"]
 serde = ["egui/serde"]
 # The enabled logs will print with the info log level, to make it less cumbersome to debug in browsers.
 log_input_events = []
@@ -51,10 +51,20 @@ name = "render_egui_to_texture"
 required-features = ["render"]
 
 [dependencies]
-bevy = { version = "0.14.0", default-features = false, features = [
-  "bevy_asset",
-  "bevy_winit",
-] }
+bevy_app = "0.14"
+bevy_asset = "0.14"
+bevy_derive = "0.14"
+bevy_ecs = "0.14"
+bevy_input = "0.14"
+bevy_log = "0.14"
+bevy_math = "0.14"
+bevy_render = { version = "0.14", optional = true }
+bevy_reflect = "0.14"
+bevy_time = "0.14"
+bevy_utils = "0.14"
+bevy_winit = "0.14"
+bevy_window = "0.14"
+encase = "0.8"
 egui = { version = "0.29", default-features = false, features = ["bytemuck"] }
 bytemuck = "1"
 webbrowser = { version = "1.0.1", optional = true }
@@ -79,18 +89,18 @@ egui = { version = "0.29", default-features = false, features = ["bytemuck"] }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 winit = "0.30"
 web-sys = { version = "0.3.63", features = [
-    "Clipboard",
-    "ClipboardEvent",
-    "CompositionEvent",
-    "DataTransfer",
-    "Document",
-    "EventTarget",
-    "HtmlInputElement",
-    "InputEvent",
-    "KeyboardEvent",
-    "Navigator",
-    "TouchEvent",
-    "Window",
+  "Clipboard",
+  "ClipboardEvent",
+  "CompositionEvent",
+  "DataTransfer",
+  "Document",
+  "EventTarget",
+  "HtmlInputElement",
+  "InputEvent",
+  "KeyboardEvent",
+  "Navigator",
+  "TouchEvent",
+  "Window",
 ] }
 js-sys = "0.3.63"
 wasm-bindgen = "0.2.84"

--- a/src/egui_node.rs
+++ b/src/egui_node.rs
@@ -4,30 +4,30 @@ use crate::{
     },
     EguiRenderOutput, EguiSettings, RenderTargetSize,
 };
-use bevy::{
-    ecs::world::{FromWorld, World},
-    prelude::{Entity, Handle, Resource},
-    render::{
-        render_asset::RenderAssetUsages,
-        render_graph::{Node, NodeRunError, RenderGraphContext},
-        render_phase::TrackedRenderPass,
-        render_resource::{
-            BindGroupLayout, BindGroupLayoutEntry, BindingType, BlendComponent, BlendFactor,
-            BlendOperation, BlendState, Buffer, BufferAddress, BufferBindingType, BufferDescriptor,
-            BufferUsages, ColorTargetState, ColorWrites, Extent3d, FragmentState, FrontFace,
-            IndexFormat, LoadOp, MultisampleState, Operations, PipelineCache, PrimitiveState,
-            RenderPassColorAttachment, RenderPassDescriptor, RenderPipelineDescriptor,
-            SamplerBindingType, Shader, ShaderStages, ShaderType, SpecializedRenderPipeline,
-            StoreOp, TextureDimension, TextureFormat, TextureSampleType, TextureViewDimension,
-            VertexBufferLayout, VertexFormat, VertexState, VertexStepMode,
-        },
-        renderer::{RenderContext, RenderDevice, RenderQueue},
-        texture::{
-            GpuImage, Image, ImageAddressMode, ImageFilterMode, ImageSampler,
-            ImageSamplerDescriptor,
-        },
-        view::{ExtractedWindow, ExtractedWindows},
+use bevy_asset::prelude::*;
+use bevy_ecs::{
+    prelude::*,
+    world::{FromWorld, World},
+};
+use bevy_render::{
+    render_asset::RenderAssetUsages,
+    render_graph::{Node, NodeRunError, RenderGraphContext},
+    render_phase::TrackedRenderPass,
+    render_resource::{
+        BindGroupLayout, BindGroupLayoutEntry, BindingType, BlendComponent, BlendFactor,
+        BlendOperation, BlendState, Buffer, BufferAddress, BufferBindingType, BufferDescriptor,
+        BufferUsages, ColorTargetState, ColorWrites, Extent3d, FragmentState, FrontFace,
+        IndexFormat, LoadOp, MultisampleState, Operations, PipelineCache, PrimitiveState,
+        RenderPassColorAttachment, RenderPassDescriptor, RenderPipelineDescriptor,
+        SamplerBindingType, Shader, ShaderStages, ShaderType, SpecializedRenderPipeline, StoreOp,
+        TextureDimension, TextureFormat, TextureSampleType, TextureViewDimension,
+        VertexBufferLayout, VertexFormat, VertexState, VertexStepMode,
     },
+    renderer::{RenderContext, RenderDevice, RenderQueue},
+    texture::{
+        GpuImage, Image, ImageAddressMode, ImageFilterMode, ImageSampler, ImageSamplerDescriptor,
+    },
+    view::{ExtractedWindow, ExtractedWindows},
 };
 use bytemuck::cast_slice;
 use egui::{TextureFilter, TextureOptions};
@@ -262,19 +262,19 @@ impl Node for EguiNode {
             primitive,
         } in paint_jobs
         {
-            let clip_urect = bevy::math::URect {
-                min: bevy::math::UVec2 {
+            let clip_urect = bevy_math::URect {
+                min: bevy_math::UVec2 {
                     x: (clip_rect.min.x * self.pixels_per_point).round() as u32,
                     y: (clip_rect.min.y * self.pixels_per_point).round() as u32,
                 },
-                max: bevy::math::UVec2 {
+                max: bevy_math::UVec2 {
                     x: (clip_rect.max.x * self.pixels_per_point).round() as u32,
                     y: (clip_rect.max.y * self.pixels_per_point).round() as u32,
                 },
             };
 
             if clip_urect
-                .intersect(bevy::math::URect::new(
+                .intersect(bevy_math::URect::new(
                     0,
                     0,
                     window_size.physical_width as u32,
@@ -498,23 +498,19 @@ impl Node for EguiNode {
                 requires_reset = false;
             }
 
-            let clip_urect = bevy::math::URect {
-                min: bevy::math::UVec2 {
+            let clip_urect = bevy_math::URect {
+                min: bevy_math::UVec2 {
                     x: (draw_command.clip_rect.min.x * self.pixels_per_point).round() as u32,
                     y: (draw_command.clip_rect.min.y * self.pixels_per_point).round() as u32,
                 },
-                max: bevy::math::UVec2 {
+                max: bevy_math::UVec2 {
                     x: (draw_command.clip_rect.max.x * self.pixels_per_point).round() as u32,
                     y: (draw_command.clip_rect.max.y * self.pixels_per_point).round() as u32,
                 },
             };
 
-            let scrissor_rect = clip_urect.intersect(bevy::math::URect::new(
-                0,
-                0,
-                physical_width,
-                physical_height,
-            ));
+            let scrissor_rect =
+                clip_urect.intersect(bevy_math::URect::new(0, 0, physical_width, physical_height));
             if scrissor_rect.is_empty() {
                 continue;
             }

--- a/src/egui_node.rs
+++ b/src/egui_node.rs
@@ -656,7 +656,7 @@ pub(crate) fn texture_options_as_sampler_descriptor(
 ///
 /// Rendering can be implemented using for example:
 /// * native wgpu rendering libraries,
-/// * or with [`bevy::render::render_phase`] approach.
+/// * or with [`bevy_render::render_phase`] approach.
 pub struct EguiBevyPaintCallback(Box<dyn EguiBevyPaintCallbackImpl>);
 
 impl EguiBevyPaintCallback {

--- a/src/egui_render_to_texture_node.rs
+++ b/src/egui_render_to_texture_node.rs
@@ -6,21 +6,19 @@ use crate::{
     render_systems::{EguiPipelines, EguiTextureBindGroups, EguiTextureId, EguiTransforms},
     EguiRenderOutput, EguiRenderToTextureHandle, EguiSettings, RenderTargetSize,
 };
-use bevy::{
-    ecs::world::World,
-    prelude::Entity,
-    render::{
-        render_asset::RenderAssets,
-        render_graph::{Node, NodeRunError, RenderGraphContext, RenderLabel},
-        render_phase::TrackedRenderPass,
-        render_resource::{
-            Buffer, BufferAddress, BufferDescriptor, BufferUsages, IndexFormat, LoadOp, Operations,
-            PipelineCache, RenderPassColorAttachment, RenderPassDescriptor, StoreOp,
-        },
-        renderer::{RenderContext, RenderDevice, RenderQueue},
-        texture::GpuImage,
+use bevy_ecs::{prelude::*, world::World};
+use bevy_render::{
+    render_asset::RenderAssets,
+    render_graph::{Node, NodeRunError, RenderGraphContext, RenderLabel},
+    render_phase::TrackedRenderPass,
+    render_resource::{
+        Buffer, BufferAddress, BufferDescriptor, BufferUsages, IndexFormat, LoadOp, Operations,
+        PipelineCache, RenderPassColorAttachment, RenderPassDescriptor, StoreOp,
     },
+    renderer::{RenderContext, RenderDevice, RenderQueue},
+    texture::GpuImage,
 };
+
 use bytemuck::cast_slice;
 
 /// [`RenderLabel`] type for the Egui Render to Texture pass.
@@ -108,19 +106,19 @@ impl Node for EguiRenderToTextureNode {
             primitive,
         } in paint_jobs
         {
-            let clip_urect = bevy::math::URect {
-                min: bevy::math::UVec2 {
+            let clip_urect = bevy_math::URect {
+                min: bevy_math::UVec2 {
                     x: (clip_rect.min.x * self.pixels_per_point).round() as u32,
                     y: (clip_rect.min.y * self.pixels_per_point).round() as u32,
                 },
-                max: bevy::math::UVec2 {
+                max: bevy_math::UVec2 {
                     x: (clip_rect.max.x * self.pixels_per_point).round() as u32,
                     y: (clip_rect.max.y * self.pixels_per_point).round() as u32,
                 },
             };
 
             if clip_urect
-                .intersect(bevy::math::URect::new(
+                .intersect(bevy_math::URect::new(
                     0,
                     0,
                     render_target_size.physical_width as u32,
@@ -307,7 +305,7 @@ impl Node for EguiRenderToTextureNode {
         let mut render_pass = TrackedRenderPass::new(device, render_pass);
 
         let Some(pipeline_id) = egui_pipelines.get(&self.render_to_texture_target) else {
-            bevy::log::error!("no egui_pipeline");
+            bevy_log::error!("no egui_pipeline");
             return Ok(());
         };
         let Some(pipeline) = pipeline_cache.get_render_pipeline(*pipeline_id) else {
@@ -341,18 +339,18 @@ impl Node for EguiRenderToTextureNode {
                 requires_reset = false;
             }
 
-            let clip_urect = bevy::math::URect {
-                min: bevy::math::UVec2 {
+            let clip_urect = bevy_math::URect {
+                min: bevy_math::UVec2 {
                     x: (draw_command.clip_rect.min.x * self.pixels_per_point).round() as u32,
                     y: (draw_command.clip_rect.min.y * self.pixels_per_point).round() as u32,
                 },
-                max: bevy::math::UVec2 {
+                max: bevy_math::UVec2 {
                     x: (draw_command.clip_rect.max.x * self.pixels_per_point).round() as u32,
                     y: (draw_command.clip_rect.max.y * self.pixels_per_point).round() as u32,
                 },
             };
-            let scrissor_rect = clip_urect.intersect(bevy::math::URect::from_corners(
-                bevy::math::UVec2::ZERO,
+            let scrissor_rect = clip_urect.intersect(bevy_math::URect::from_corners(
+                bevy_math::UVec2::ZERO,
                 gpu_image.size,
             ));
             if scrissor_rect.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -724,7 +724,7 @@ impl Plugin for EguiPlugin {
         {
             use std::sync::{LazyLock, Mutex};
 
-            let maybe_window_plugin = app.get_added_plugins::<bevy::prelude::WindowPlugin>();
+            let maybe_window_plugin = app.get_added_plugins::<bevy_window::WindowPlugin>();
 
             if !maybe_window_plugin.is_empty()
                 && maybe_window_plugin[0].primary_window.is_some()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,10 +92,10 @@ use crate::{
     not(any(target_arch = "wasm32", target_os = "android"))
 ))]
 use arboard::Clipboard;
+
 #[cfg(feature = "render")]
-use bevy_app::Last;
 use bevy_asset::{load_internal_asset, AssetEvent, Assets, Handle};
-use bevy_ecs::{event::EventReader, system::ResMut};
+#[cfg(feature = "render")]
 use bevy_render::{
     extract_component::{ExtractComponent, ExtractComponentPlugin},
     extract_resource::{ExtractResource, ExtractResourcePlugin},
@@ -103,9 +103,8 @@ use bevy_render::{
     texture::{Image, ImageSampler},
     ExtractSchedule, Render, RenderApp, RenderSet,
 };
-use bevy_utils::HashMap;
 
-use bevy_app::{App, Plugin, PostUpdate, PreStartup, PreUpdate};
+use bevy_app::prelude::*;
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     prelude::*,
@@ -114,14 +113,9 @@ use bevy_ecs::{
     system::SystemParam,
 };
 use bevy_input::InputSystem;
-
 use bevy_reflect::Reflect;
 use bevy_window::{PrimaryWindow, Window};
 
-#[cfg(feature = "render")]
-use bevy_ecs::query::Or;
-#[allow(unused_imports)]
-use bevy_log;
 #[cfg(all(
     feature = "manage_clipboard",
     not(any(target_arch = "wasm32", target_os = "android"))
@@ -561,7 +555,7 @@ pub struct EguiRenderToTextureHandle(pub Handle<Image>);
 #[derive(Clone, bevy_ecs::system::Resource, Default, ExtractResource)]
 #[cfg(feature = "render")]
 pub struct EguiUserTextures {
-    textures: HashMap<Handle<Image>, u64>,
+    textures: bevy_utils::HashMap<Handle<Image>, u64>,
     last_texture_id: u64,
 }
 
@@ -900,7 +894,7 @@ impl EguiContextQueryItem<'_> {
 /// Contains textures allocated and painted by Egui.
 #[cfg(feature = "render")]
 #[derive(bevy_ecs::system::Resource, Deref, DerefMut, Default)]
-pub struct EguiManagedTextures(pub HashMap<(Entity, u64), EguiManagedTexture>);
+pub struct EguiManagedTextures(pub bevy_utils::HashMap<(Entity, u64), EguiManagedTexture>);
 
 /// Represents a texture allocated and painted by Egui.
 #[cfg(feature = "render")]

--- a/src/render_systems.rs
+++ b/src/render_systems.rs
@@ -4,24 +4,25 @@ use crate::{
     EguiManagedTextures, EguiRenderToTextureHandle, EguiSettings, EguiUserTextures,
     RenderTargetSize,
 };
-use bevy::{
-    ecs::system::SystemParam,
-    prelude::*,
-    render::{
-        extract_resource::ExtractResource,
-        render_asset::RenderAssets,
-        render_graph::{RenderGraph, RenderLabel},
-        render_resource::{
-            BindGroup, BindGroupEntry, BindingResource, BufferId, CachedRenderPipelineId,
-            DynamicUniformBuffer, PipelineCache, ShaderType, SpecializedRenderPipelines,
-        },
-        renderer::{RenderDevice, RenderQueue},
-        texture::GpuImage,
-        view::ExtractedWindows,
-        Extract,
+use bevy_asset::prelude::*;
+use bevy_derive::{Deref, DerefMut};
+use bevy_ecs::{prelude::*, system::SystemParam};
+use bevy_math::Vec2;
+use bevy_render::{
+    extract_resource::ExtractResource,
+    render_asset::RenderAssets,
+    render_graph::{RenderGraph, RenderLabel},
+    render_resource::{
+        BindGroup, BindGroupEntry, BindingResource, BufferId, CachedRenderPipelineId,
+        DynamicUniformBuffer, PipelineCache, SpecializedRenderPipelines,
     },
-    utils::HashMap,
+    renderer::{RenderDevice, RenderQueue},
+    texture::{GpuImage, Image},
+    view::ExtractedWindows,
+    Extract,
 };
+use bevy_utils::HashMap;
+use bevy_window::Window;
 
 /// Extracted Egui settings.
 #[derive(Resource, Deref, DerefMut, Default)]
@@ -98,7 +99,7 @@ pub fn setup_new_windows_render_system(
 
         render_graph.add_node(egui_pass.clone(), new_node);
 
-        render_graph.add_node_edge(bevy::render::graph::CameraDriverLabel, egui_pass);
+        render_graph.add_node_edge(bevy_render::graph::CameraDriverLabel, egui_pass);
     }
 }
 /// Sets up the pipeline for newly created Render to texture entities.
@@ -116,7 +117,7 @@ pub fn setup_new_rtt_render_system(
 
         render_graph.add_node(egui_rtt_pass.clone(), new_node);
 
-        render_graph.add_node_edge(egui_rtt_pass, bevy::render::graph::CameraDriverLabel);
+        render_graph.add_node_edge(egui_rtt_pass, bevy_render::graph::CameraDriverLabel);
     }
 }
 
@@ -133,7 +134,7 @@ pub struct EguiTransforms {
 
 /// Scale and translation for rendering Egui shapes. Is needed to transform Egui coordinates from
 /// the screen space with the center at (0, 0) to the normalised viewport space.
-#[derive(ShaderType, Default)]
+#[derive(encase::ShaderType, Default)]
 pub struct EguiTransform {
     /// Is affected by window size and [`EguiSettings::scale_factor`].
     pub scale: Vec2,

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -25,6 +25,7 @@ use bevy_winit::{EventLoopProxy, WakeUp};
 
 #[cfg(feature = "render")]
 use bevy_asset::Assets;
+#[cfg(feature = "render")]
 use bevy_render::texture::Image;
 use std::{marker::PhantomData, time::Duration};
 

--- a/src/text_agent.rs
+++ b/src/text_agent.rs
@@ -3,10 +3,9 @@
 
 use std::sync::{LazyLock, Mutex};
 
-use bevy::{
-    prelude::{EventWriter, NonSendMut, Res, Resource},
-    window::RequestRedraw,
-};
+use bevy_ecs::prelude::*;
+use bevy_window::RequestRedraw;
+
 use crossbeam_channel::{unbounded, Receiver, Sender};
 
 use wasm_bindgen::prelude::*;
@@ -364,21 +363,21 @@ pub fn update_text_agent(editing_text: bool) {
     let window = match web_sys::window() {
         Some(window) => window,
         None => {
-            bevy::log::error!("No window found");
+            bevy_log::error!("No window found");
             return;
         }
     };
     let document = match window.document() {
         Some(doc) => doc,
         None => {
-            bevy::log::error!("No document found");
+            bevy_log::error!("No document found");
             return;
         }
     };
     let input: HtmlInputElement = match document.get_element_by_id(AGENT_ID) {
         Some(ele) => ele,
         None => {
-            bevy::log::error!("Agent element not found");
+            bevy_log::error!("Agent element not found");
             return;
         }
     }
@@ -393,13 +392,13 @@ pub fn update_text_agent(editing_text: bool) {
         match input.focus().ok() {
             Some(_) => {}
             None => {
-                bevy::log::error!("Unable to set focus");
+                bevy_log::error!("Unable to set focus");
             }
         }
     } else if keyboard_open {
         // Close the keyboard.
         if input.blur().is_err() {
-            bevy::log::error!("Agent element not found");
+            bevy_log::error!("Agent element not found");
             return;
         }
 

--- a/src/web_clipboard.rs
+++ b/src/web_clipboard.rs
@@ -1,5 +1,6 @@
 use crate::{string_from_js_value, EguiClipboard, EventClosure, SubscribedEvents};
-use bevy::{log, prelude::*};
+use bevy_ecs::prelude::*;
+use bevy_log as log;
 use crossbeam_channel::{Receiver, Sender};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::spawn_local;


### PR DESCRIPTION
`bevy_egui` was causing compilation of our large projects to delay until `bevy`, and more critically, `bevy_pbr` were done compiling. `bevy_pbr` is extremely slow, and depends on `bevy_render`, which is also slow to compile. The result is compilation cannot parallelize well.

This change should be entirely idempotent for users, it simply switches dependencies to the bevy subcrates. The effect of this is that bevy_egui, and anything that depend on it, can now start compiling at the same time as `bevy_pbr`, this had a huge positive effect on compile times in our larger project, because many things depend on `bevy_egui`.

The only "gotcha" here is that I had to depend on `encase` manually, otherwise you end up needing to go through bevy's `ShaderType` derive, which falls over when `bevy` is not in scope.

Using `--timings` on the `simple` example, on an M3 Max:

Before
![image](https://github.com/user-attachments/assets/524b15c5-3922-4efb-a073-c6c6d3167078)

After
![image](https://github.com/user-attachments/assets/e683d752-c77d-4941-9caf-35f5a50b8bd5)

As expected, this has no impact on the compile time of examples, because `bevy_pbr` still dominates, but in real applications, you will usually have a bunch of crates depending on `bevy_egui`, which can now start compiling a whole 4 seconds earlier (and even more on slower machines).