### PR TITLE
attempt to fix spurious panic when closing window

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -95,10 +95,14 @@ pub fn process_output_system(
             if let Some(window_entity) = window_to_egui_context_map.context_to_window.get(&entity) {
                 let last_cursor_icon = last_cursor_icon.entry(entity).or_default();
                 if *last_cursor_icon != egui_output.platform_output.cursor_icon {
-                    commands.entity(*window_entity).insert(CursorIcon::System(
-                        helpers::egui_to_winit_cursor_icon(egui_output.platform_output.cursor_icon)
+                    commands
+                        .entity(*window_entity)
+                        .try_insert(CursorIcon::System(
+                            helpers::egui_to_winit_cursor_icon(
+                                egui_output.platform_output.cursor_icon,
+                            )
                             .unwrap_or(bevy_window::SystemCursorIcon::Default),
-                    ));
+                        ));
                     *last_cursor_icon = egui_output.platform_output.cursor_icon;
                 }
             }


### PR DESCRIPTION
Attempts to fix https://github.com/bevyengine/bevy/issues/21318.

I haven't validated that this works, as I was only getting the panic occasionally.
Maybe there's a better fix where bevy_egui tracks if the windows still exists better. Or the system just needs a `after/before` constraint.

But this should be good enough probably.