### PR TITLE
Added partial update support for egui textures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ render = [
     "bevy_image",
     "bevy_mesh",
     "bevy_render",
+    "bevy_color",
     "bevy_shader",
     "bevy_transform",
     "encase",
@@ -111,6 +112,7 @@ bevy_core_pipeline = { version = "0.17.0", optional = true }
 bevy_image = { version = "0.17.0", features = ["zstd_rust"], optional = true }
 bevy_mesh = { version = "0.17.0", optional = true }
 bevy_render = { version = "0.17.0", optional = true }
+bevy_color = { version = "0.17.0", optional = true }
 bevy_shader = { version = "0.17.0", optional = true }
 bevy_transform = { version = "0.17.0", optional = true }
 encase = { version = "0.11", optional = true }


### PR DESCRIPTION
Since bevy 0.15 we can now [easily write into textures](https://bevy.org/news/bevy-0-15/#user-friendly-cpu-drawing). This PR resolves a current TODO and also solves https://github.com/vladbat00/bevy_egui/issues/431.