### PR TITLE
Add support for egui built-in ctrl+/- and other zoom behaviours

### DIFF
--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -108,8 +108,7 @@ fn update_ui_scale_factor_system(
         };
         egui_settings.scale_factor = scale_factor;
     }
-    
-    
+        
     // Handle Ctrl+] (zoom in) and Ctrl+[ (zoom out)
     // Using different keybinds than egui's default Ctrl+Plus/Minus to avoid conflicts
     let ctrl_pressed = keyboard_input.pressed(KeyCode::ControlLeft)

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -24,8 +24,11 @@ impl FromWorld for Images {
 
 /// This example demonstrates the following functionality and use-cases of bevy_egui:
 /// - rendering loaded assets;
-/// - toggling hidpi scaling (by pressing '/' button);
-/// - configuring egui contexts during the startup.
+/// - configuring egui contexts during the startup;
+/// - custom zoom controls via EguiContextSettings (Ctrl+] / Ctrl+[ to zoom in/out).
+///
+/// Note: Egui's built-in zoom controls (Ctrl+Plus / Ctrl+Minus / Ctrl+0) now work correctly
+/// and are synchronized with bevy_egui's scale_factor!
 fn main() {
     App::new()
         .insert_resource(ClearColor(Color::BLACK))
@@ -103,6 +106,27 @@ fn update_ui_scale_factor_system(
             1.0 / camera.target_scaling_factor().unwrap_or(1.0)
         };
         egui_settings.scale_factor = scale_factor;
+    }
+    
+    
+    // Handle Ctrl+] (zoom in) and Ctrl+[ (zoom out)
+    // Using different keybinds than egui's default Ctrl+Plus/Minus to avoid conflicts
+    let ctrl_pressed = keyboard_input.pressed(KeyCode::ControlLeft)
+        || keyboard_input.pressed(KeyCode::ControlRight);
+    if ctrl_pressed && keyboard_input.just_pressed(KeyCode::BracketRight) {
+        // Ctrl+] (zoom in via scale_factor)
+        egui_settings.scale_factor = (egui_settings.scale_factor * 1.1).min(5.0);
+        info!(
+            "Zoom in (via scale_factor) - scale factor: {}",
+            egui_settings.scale_factor
+        );
+    } else if ctrl_pressed && keyboard_input.just_pressed(KeyCode::BracketLeft) {
+        // Ctrl+[ (zoom out via scale_factor)
+        egui_settings.scale_factor = (egui_settings.scale_factor / 1.1).max(0.1);
+        info!(
+            "Zoom out (via scale_factor) - scale factor: {}",
+            egui_settings.scale_factor
+        );
     }
 }
 

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -26,6 +26,7 @@ impl FromWorld for Images {
 /// - rendering loaded assets;
 /// - configuring egui contexts during the startup;
 /// - custom zoom controls via EguiContextSettings (Ctrl+] / Ctrl+[ to zoom in/out).
+/// - toggling hidpi scaling (by pressing '/' button);
 ///
 /// Note: Egui's built-in zoom controls (Ctrl+Plus / Ctrl+Minus / Ctrl+0) now work correctly
 /// and are synchronized with bevy_egui's scale_factor!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -440,7 +440,10 @@ pub struct EguiContextSettings {
     /// }
     /// ```
     pub scale_factor: f32,
-    /// Consolidated cache of scale factors to detect the source of change and prevent feedback loops.
+    /// Internal cache of scale factors used to detect the source of changes and prevent feedback loops.
+    /// 
+    /// This cache is maintained automatically by the Egui integration systems. 
+    /// API users typically should not modify this field directly unless implementing custom scale factor logic.
     pub scale_factor_cache: ScaleFactorCache,
     /// Is used as a default value for hyperlink [target](https://www.w3schools.com/tags/att_a_target.asp) hints.
     /// If not specified, `_self` will be used. Only matters in a web browser.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -493,11 +493,13 @@ impl Default for EguiContextSettings {
 #[derive(Clone, Debug, Reflect)]
 pub struct ScaleFactorCache {
     /// Last known camera native scale (DPI / devicePixelRatio etc.).
-    last_camera_scale: f32,
+    pub last_camera_scale: f32,
     /// Last known bevy_egui scale factor (user/programmatic override managed by bevy_egui).
-    last_bevy_scale: f32,
+    pub last_bevy_scale: f32,
     /// Last known egui zoom factor (driven by egui hotkeys or API calls).
-    last_egui_zoom: f32,
+    pub last_egui_zoom: f32,
+    /// Bevy scale factor applied when building the current frame's raw input/render data.
+    pub render_applied_bevy_scale: f32,
 }
 
 impl Default for ScaleFactorCache {
@@ -506,6 +508,7 @@ impl Default for ScaleFactorCache {
             last_camera_scale: 1.0,
             last_bevy_scale: 1.0,
             last_egui_zoom: 1.0,
+            render_applied_bevy_scale: 1.0,
         }
     }
 }
@@ -1863,6 +1866,9 @@ pub fn update_ui_size_and_scale_system(mut contexts: Query<UpdateUiSizeAndScaleQ
         }
 
         // 4) Compute the effective pixels-per-point contribution from camera * bevy override
+        context.egui_settings
+            .scale_factor_cache
+            .render_applied_bevy_scale = context.egui_settings.scale_factor;
         let combined_pixels_per_point =
             (camera_scale * context.egui_settings.scale_factor).max(0.0001);
         let current_zoom = context.ctx.get_mut().zoom_factor();

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -189,7 +189,9 @@ pub fn extract_egui_camera_view_system(
                     EguiViewTarget(render_entity),
                     egui_render_output,
                     RenderComputedScaleFactor {
-                        scale_factor: settings.scale_factor
+                        scale_factor: settings
+                            .scale_factor_cache
+                            .render_applied_bevy_scale
                             * camera.target_scaling_factor().unwrap_or(1.0),
                     },
                     TemporaryRenderEntity,


### PR DESCRIPTION
Egui provides some built-in zoom factor manipulation.

Egui includes:
- ctrl+'+'
- ctrl+'-'
- ctrl+'0'
- `zoom_menu_buttons(ui);`

When using the `ui.rs` example before applying this change, when using the built-in egui scaling hotkeys, the UI flickers for one frame but there is no resulting scale change.

These proposed changes add support for changes to egui zoom_factor being propagated back to the bevy_egui scale_factor.

The changes include adding `ctrl+[` and `ctrl+]` hotkeys to the `ui.rs` example to demonstrate that both egui and bevy_egui can harmoniously adjust the zoom factor with no one-frame problems.

To experience the changes, run the ui.rs example and use the `ctrl+[`, `ctrl+]`, `ctrl+'+'`, `ctrl+'-'` hotkeys to observe scale changes being initiated from both egui and bevy_egui.

It's a bit fiddly to make sure that the values are synced properly while allowing either to initiate a change with no flickering lol

My understanding is that the bevy_egui scale factor was introduced before egui had its own scale factor, so there's future opportunity to remove the bevy_egui scale factor entirely, but until then this should be a good middle ground.

related: https://github.com/vladbat00/bevy_egui/issues/244