### PR TITLE
Add `prelude` module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,16 @@ pub mod text_agent;
 #[cfg(all(feature = "manage_clipboard", target_arch = "wasm32",))]
 pub mod web_clipboard;
 
+/// Commonly-used items.
+pub mod prelude {
+    pub use crate::{
+        EguiContext, EguiContextSettings, EguiContexts, EguiGlobalSettings, EguiMultipassSchedule,
+        EguiPlugin, EguiPrimaryContextPass, EguiStartupSet, PrimaryEguiContext, egui,
+    };
+    #[cfg(feature = "render")]
+    pub use crate::{EguiTextureHandle, EguiUserTextures};
+}
+
 pub use egui;
 
 use crate::input::*;


### PR DESCRIPTION
Add a `prelude` module, following the conventions in the bevy ecosystem.

The heuristic I'm using is that any items used more than once in the `examples` gets included in the `prelude`:

```bash
$ cd examples
$ rg -IUo --multiline-dotall -r '$1' "use bevy_egui::\{\n?(.*?)\n?\};" | 
    sed -E 's/^ +//g; s/,$//' | 
    perl -pe 's/^(\w+)::\{(.+)\}$/join(", ", map "$1::$_", split ", ", $2)/ge' | 
    sed -E 's/, /\n/g' | sort | uniq -c | sort -nr
     12 EguiPlugin
     11 EguiPrimaryContextPass
     10 EguiContexts
      8 EguiGlobalSettings
      7 PrimaryEguiContext
      6 EguiContext
      5 EguiMultipassSchedule
      5 egui
      4 EguiTextureHandle
      3 EguiContextSettings
      2 EguiUserTextures
      2 EguiStartupSet
      1 render::EguiPipelineKey
      1 render::EguiBevyPaintCallbackImpl
      1 render::EguiBevyPaintCallback
      1 picking::PickableEguiContext
      1 input::HoveredNonWindowEguiContext
      1 input::egui_wants_any_pointer_input
      1 input::egui_wants_any_keyboard_input
      1 input::EguiContextPointerPosition
      1 helpers::vec2_into_egui_pos2
      1 egui::Widget
      1 EguiInputSet
      1 EguiInput
      1 EguiFullOutput
      1 BevyEguiEntityCommandsExt
```

If you want to see any changes, let me know!