### PR TITLE
Update bevy from 0.17.0 to 0.17.2 and update rust version from 1.85 to 1.88

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bevy_egui"
 version = "0.38.0"
 # Needed for the 2024 edition.
-rust-version = "1.85.0"
+rust-version = "1.88.0"
 authors = ["vladbat00 <vladyslav.batyrenko@gmail.com>"]
 description = "A plugin for Egui integration into Bevy"
 license = "MIT"
@@ -85,20 +85,20 @@ required-features = ["render"]
 
 [dependencies]
 egui = { version = "0.33", default-features = false }
-bevy_a11y = { version = "0.17.0", optional = true }
-bevy_app = { version = "0.17.0" }
-bevy_camera = { version = "0.17.0" }
-bevy_derive = { version = "0.17.0" }
-bevy_ecs = { version = "0.17.0" }
-bevy_input = { version = "0.17.0" }
-bevy_log = { version = "0.17.0" }
-bevy_math = { version = "0.17.0" }
-bevy_platform = { version = "0.17.0" }
-bevy_reflect = { version = "0.17.0" }
-bevy_time = { version = "0.17.0" }
-bevy_window = { version = "0.17.0" }
-bevy_winit = { version = "0.17.0" }
-bevy_utils = { version = "0.17.0", features = ["debug"] }
+bevy_a11y = { version = "0.17.2", optional = true }
+bevy_app = { version = "0.17.2" }
+bevy_camera = { version = "0.17.2" }
+bevy_derive = { version = "0.17.2" }
+bevy_ecs = { version = "0.17.2" }
+bevy_input = { version = "0.17.2" }
+bevy_log = { version = "0.17.2" }
+bevy_math = { version = "0.17.2" }
+bevy_platform = { version = "0.17.2" }
+bevy_reflect = { version = "0.17.2" }
+bevy_time = { version = "0.17.2" }
+bevy_window = { version = "0.17.2" }
+bevy_winit = { version = "0.17.2" }
+bevy_utils = { version = "0.17.2", features = ["debug"] }
 winit = { version = "0.30", default-features = false }
 
 # `open_url` feature
@@ -107,23 +107,23 @@ webbrowser = { version = "1.0.1", optional = true }
 # `render` feature
 bytemuck = { version = "1", optional = true }
 
-bevy_asset = { version = "0.17.0", optional = true }
-bevy_core_pipeline = { version = "0.17.0", optional = true }
-bevy_image = { version = "0.17.0", features = ["zstd_rust"], optional = true }
-bevy_mesh = { version = "0.17.0", optional = true }
-bevy_render = { version = "0.17.0", optional = true }
-bevy_color = { version = "0.17.0", optional = true }
-bevy_shader = { version = "0.17.0", optional = true }
-bevy_transform = { version = "0.17.0", optional = true }
+bevy_asset = { version = "0.17.2", optional = true }
+bevy_core_pipeline = { version = "0.17.2", optional = true }
+bevy_image = { version = "0.17.2", features = ["zstd_rust"], optional = true }
+bevy_mesh = { version = "0.17.2", optional = true }
+bevy_render = { version = "0.17.2", optional = true }
+bevy_color = { version = "0.17.2", optional = true }
+bevy_shader = { version = "0.17.2", optional = true }
+bevy_transform = { version = "0.17.2", optional = true }
 encase = { version = "0.11", optional = true }
 itertools = { version = "0.14", optional = true }
 wgpu-types = { version = "26.0", optional = true }
 
 # `bevy_ui` feature
-bevy_ui_render = { version = "0.17.0", optional = true }
+bevy_ui_render = { version = "0.17.2", optional = true }
 
 # `picking` feature
-bevy_picking = { version = "0.17.0", optional = true, features = ["bevy_mesh_picking_backend"] }
+bevy_picking = { version = "0.17.2", optional = true, features = ["bevy_mesh_picking_backend"] }
 
 # `manage_clipboard` feature
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
@@ -132,7 +132,7 @@ thread_local = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9.5"
-bevy = { version = "0.17.0", default-features = false, features = [
+bevy = { version = "0.17.2", default-features = false, features = [
     "bevy_log",
     "bevy_asset",
     "bevy_core_pipeline",
@@ -154,7 +154,7 @@ bevy = { version = "0.17.0", default-features = false, features = [
 egui = { version = "0.33", default-features = false, features = ["bytemuck"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-bevy = { version = "0.17.0", default-features = false, features = ["accesskit_unix"] }
+bevy = { version = "0.17.2", default-features = false, features = ["accesskit_unix"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dev-dependencies]
 rfd = "0.15"


### PR DESCRIPTION
Hi. I am Alan. I am a first time contributor. I had some issues with mismatched bevy versions on a 0.17.2 bevy project. So I updated the versions on the Cargo.toml file. During the tests cargo said that bevy 0.17.2 required 1.88 over 1.85, so I updated it too.