### PR TITLE
BUGFIX: Fix HiDPI click registration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1840,6 +1840,15 @@ pub fn update_ui_size_and_scale_system(mut contexts: Query<UpdateUiSizeAndScaleQ
         }
         context.egui_input.screen_rect = Some(viewport_rect);
         context.ctx.get_mut().set_pixels_per_point(scale_factor);
+
+        // Set inner_rect in ViewportInfo for proper hit testing on HiDPI displays.
+        // Without this, egui's cached hit testing (InteractionSnapshot) fails because
+        // it uses inner_rect to validate pointer positions within the viewport.
+        let viewport_id = context.egui_input.viewport_id;
+        if let Some(viewport_info) = context.egui_input.viewports.get_mut(&viewport_id) {
+            viewport_info.inner_rect = Some(viewport_rect);
+            viewport_info.native_pixels_per_point = Some(scale_factor);
+        }
     }
 }
 


### PR DESCRIPTION
Fix HiDPI click registration by setting ViewportInfo.inner_rect on HiDPI displays (e.g., macOS Retina with 2x scaling), egui's cached hit testing via InteractionSnapshot was failing because inner_rect was never set in the ViewportInfo.

The issue manifests as:
  - response.clicked() always returns false
  - response.hovered() always returns false
  - response.contains_pointer() always returns false
  - Live geometric checks (ctx.rect_contains_pointer()) work correctly
This happens because egui's hit_test() function validates pointer positions against the viewport's inner_rect. When inner_rect is None the default), the validation fails silently, resulting in an empty InteractionSnapshot with no widgets registered as containing the pointer.

The fix sets both inner_rect and native_pixels_per_point in the ViewportInfo during the scale/size update, ensuring egui has the correct viewport bounds for hit testing.

Tested on macOS with 2x Retina display.