### PR TITLE
Support trackpad pinch-to-zoom on macOS

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -11,6 +11,7 @@ use bevy_ecs::{
 };
 use bevy_input::{
     ButtonInput, ButtonState,
+    gestures::PinchGesture,
     keyboard::{Key, KeyCode, KeyboardFocusLost, KeyboardInput},
     mouse::{MouseButton, MouseButtonInput, MouseScrollUnit, MouseWheel},
     touch::TouchInput,
@@ -548,6 +549,40 @@ pub fn write_mouse_wheel_messages_system(
                 modifiers,
             },
         });
+    }
+}
+
+/// Reads [`PinchGesture`] messages and wraps them into [`EguiInputEvent`] with [`egui::Event::Zoom`].
+///
+/// Bevy's `PinchGesture` doesn't carry a window entity, so this broadcasts to all window contexts
+/// (or the hovered non-window context if one exists).
+pub fn write_pinch_gesture_messages_system(
+    mut pinch_reader: MessageReader<PinchGesture>,
+    hovered_non_window_egui_context: Option<Res<HoveredNonWindowEguiContext>>,
+    mut egui_input_message_writer: MessageWriter<EguiInputEvent>,
+    map: Res<WindowToEguiContextMap>,
+) {
+    for message in pinch_reader.read() {
+        // Match egui-winit: positive delta = magnification, negative = shrink
+        let zoom_factor = message.0.exp();
+
+        if let Some(HoveredNonWindowEguiContext(context)) =
+            hovered_non_window_egui_context.as_deref()
+        {
+            egui_input_message_writer.write(EguiInputEvent {
+                context: *context,
+                event: egui::Event::Zoom(zoom_factor),
+            });
+        } else {
+            for contexts in map.window_to_contexts.values() {
+                for &context in contexts {
+                    egui_input_message_writer.write(EguiInputEvent {
+                        context,
+                        event: egui::Event::Zoom(zoom_factor),
+                    });
+                }
+            }
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -500,6 +500,8 @@ pub struct EguiInputSystemSettings {
     pub run_write_non_window_pointer_moved_messages_system: bool,
     /// Controls running of the [`write_mouse_wheel_messages_system`] system.
     pub run_write_mouse_wheel_messages_system: bool,
+    /// Controls running of the [`write_pinch_gesture_messages_system`] system.
+    pub run_write_pinch_gesture_messages_system: bool,
     /// Controls running of the [`write_non_window_touch_messages_system`] system.
     pub run_write_non_window_touch_messages_system: bool,
     /// Controls running of the [`write_keyboard_input_messages_system`] system.
@@ -525,6 +527,7 @@ impl Default for EguiInputSystemSettings {
             run_write_window_touch_messages_system: true,
             run_write_non_window_pointer_moved_messages_system: true,
             run_write_mouse_wheel_messages_system: true,
+            run_write_pinch_gesture_messages_system: true,
             run_write_non_window_touch_messages_system: true,
             run_write_keyboard_input_messages_system: true,
             run_write_ime_messages_system: true,
@@ -1086,6 +1089,9 @@ impl Plugin for EguiPlugin {
                     })),
                     write_mouse_wheel_messages_system.run_if(input_system_is_enabled(|s| {
                         s.run_write_mouse_wheel_messages_system
+                    })),
+                    write_pinch_gesture_messages_system.run_if(input_system_is_enabled(|s| {
+                        s.run_write_pinch_gesture_messages_system
                     })),
                     write_keyboard_input_messages_system.run_if(input_system_is_enabled(|s| {
                         s.run_write_keyboard_input_messages_system


### PR DESCRIPTION
Hiya, this PR adds `write_pinch_gesture_messages_system` - which reads bevy's PinchGesture messages and forwards it onto egui. The formula matches what I found [here on egui-winit](https://github.com/emilk/egui/blob/64a96ef3917d4e305a79fa5f460af5fc73eabcf8/crates/egui-winit/src/lib.rs#L488).

Tested fully on my mac machine and pinching works for me