### PR TITLE
Bevy 0.19 + Egui 0.34

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ bevy_shader = { version = "0.19.0-dev", optional = true }
 bevy_transform = { version = "0.19.0-dev", optional = true }
 encase = { version = "0.12", optional = true }
 itertools = { version = "0.14", optional = true }
-wgpu-types = { version = "29.0.1", optional = true }
+wgpu-types = { version = "29.0.3", optional = true }
 
 # `bevy_ui` feature
 bevy_ui_render = { version = "0.19.0-dev", optional = true }
@@ -188,28 +188,28 @@ crossbeam-channel = "0.5.8"
 getrandom = { version = "0.3", features = ["wasm_js"] }
 
 [patch."crates-io"]
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
-bevy_a11y = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
-bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
-bevy_camera = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
-bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
-bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
-bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
-bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
-bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
-bevy_platform = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
-bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
-bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
-bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
-bevy_winit = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
-bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
-bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
-bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
-bevy_image = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
-bevy_mesh = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
-bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
-bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
-bevy_shader = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
-bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
-bevy_picking = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
-bevy_ui_render = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
+bevy_a11y = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
+bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
+bevy_camera = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
+bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
+bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
+bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
+bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
+bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
+bevy_platform = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
+bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
+bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
+bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
+bevy_winit = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
+bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
+bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
+bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
+bevy_image = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
+bevy_mesh = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
+bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
+bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
+bevy_shader = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
+bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
+bevy_picking = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
+bevy_ui_render = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,20 +84,20 @@ required-features = ["render"]
 
 [dependencies]
 egui = { version = "0.34", default-features = false }
-bevy_a11y = { version = "0.19.0-rc.1", optional = true }
-bevy_app = { version = "0.19.0-rc.1" }
-bevy_camera = { version = "0.19.0-rc.1" }
-bevy_derive = { version = "0.19.0-rc.1" }
-bevy_ecs = { version = "0.19.0-rc.1" }
-bevy_input = { version = "0.19.0-rc.1" }
-bevy_log = { version = "0.19.0-rc.1" }
-bevy_math = { version = "0.19.0-rc.1" }
-bevy_platform = { version = "0.19.0-rc.1" }
-bevy_reflect = { version = "0.19.0-rc.1" }
-bevy_time = { version = "0.19.0-rc.1" }
-bevy_window = { version = "0.19.0-rc.1" }
-bevy_winit = { version = "0.19.0-rc.1" }
-bevy_utils = { version = "0.19.0-rc.1", features = ["debug"] }
+bevy_a11y = { version = "0.19.0-rc.2", optional = true }
+bevy_app = { version = "0.19.0-rc.2" }
+bevy_camera = { version = "0.19.0-rc.2" }
+bevy_derive = { version = "0.19.0-rc.2" }
+bevy_ecs = { version = "0.19.0-rc.2" }
+bevy_input = { version = "0.19.0-rc.2" }
+bevy_log = { version = "0.19.0-rc.2" }
+bevy_math = { version = "0.19.0-rc.2" }
+bevy_platform = { version = "0.19.0-rc.2" }
+bevy_reflect = { version = "0.19.0-rc.2" }
+bevy_time = { version = "0.19.0-rc.2" }
+bevy_window = { version = "0.19.0-rc.2" }
+bevy_winit = { version = "0.19.0-rc.2" }
+bevy_utils = { version = "0.19.0-rc.2", features = ["debug"] }
 winit = { version = "0.30", default-features = false }
 
 # `open_url` feature
@@ -106,23 +106,23 @@ webbrowser = { version = "1.0.1", optional = true }
 # `render` feature
 bytemuck = { version = "1", optional = true }
 
-bevy_asset = { version = "0.19.0-rc.1", optional = true }
-bevy_core_pipeline = { version = "0.19.0-rc.1", optional = true }
-bevy_image = { version = "0.19.0-rc.1", features = ["zstd_rust"], optional = true }
-bevy_mesh = { version = "0.19.0-rc.1", optional = true }
-bevy_render = { version = "0.19.0-rc.1", optional = true }
-bevy_color = { version = "0.19.0-rc.1", optional = true }
-bevy_shader = { version = "0.19.0-rc.1", optional = true }
-bevy_transform = { version = "0.19.0-rc.1", optional = true }
+bevy_asset = { version = "0.19.0-rc.2", optional = true }
+bevy_core_pipeline = { version = "0.19.0-rc.2", optional = true }
+bevy_image = { version = "0.19.0-rc.2", features = ["zstd_rust"], optional = true }
+bevy_mesh = { version = "0.19.0-rc.2", optional = true }
+bevy_render = { version = "0.19.0-rc.2", optional = true }
+bevy_color = { version = "0.19.0-rc.2", optional = true }
+bevy_shader = { version = "0.19.0-rc.2", optional = true }
+bevy_transform = { version = "0.19.0-rc.2", optional = true }
 encase = { version = "0.12", optional = true }
 itertools = { version = "0.14", optional = true }
 wgpu-types = { version = "29.0.3", optional = true }
 
 # `bevy_ui` feature
-bevy_ui_render = { version = "0.19.0-rc.1", optional = true }
+bevy_ui_render = { version = "0.19.0-rc.2", optional = true }
 
 # `picking` feature
-bevy_picking = { version = "0.19.0-rc.1", optional = true, features = ["mesh_picking"] }
+bevy_picking = { version = "0.19.0-rc.2", optional = true, features = ["mesh_picking"] }
 
 # `manage_clipboard` feature
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
@@ -131,7 +131,7 @@ thread_local = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9.5"
-bevy = { version = "0.19.0-rc.1", default-features = false, features = [
+bevy = { version = "0.19.0-rc.2", default-features = false, features = [
     "bevy_log",
     "bevy_asset",
     "bevy_core_pipeline",
@@ -159,7 +159,7 @@ bevy = { version = "0.19.0-rc.1", default-features = false, features = [
 egui = { version = "0.34", default-features = false, features = ["bytemuck"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-bevy = { version = "0.19.0-rc.1", default-features = false, features = ["accesskit_unix"] }
+bevy = { version = "0.19.0-rc.2", default-features = false, features = ["accesskit_unix"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dev-dependencies]
 rfd = "0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,20 +84,20 @@ required-features = ["render"]
 
 [dependencies]
 egui = { version = "0.33", default-features = false }
-bevy_a11y = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", optional = true }
-bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
-bevy_camera = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
-bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
-bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
-bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
-bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
-bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
-bevy_platform = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
-bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
-bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
-bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
-bevy_winit = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
-bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", features = ["debug"] }
+bevy_a11y = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", optional = true }
+bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194" }
+bevy_camera = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194" }
+bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194" }
+bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194" }
+bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194" }
+bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194" }
+bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194" }
+bevy_platform = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194" }
+bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194" }
+bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194" }
+bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194" }
+bevy_winit = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194" }
+bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", features = ["debug"] }
 winit = { version = "0.30", default-features = false }
 
 # `open_url` feature
@@ -106,23 +106,23 @@ webbrowser = { version = "1.0.1", optional = true }
 # `render` feature
 bytemuck = { version = "1", optional = true }
 
-bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", optional = true }
-bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", optional = true }
-bevy_image = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", features = ["zstd_rust"], optional = true }
-bevy_mesh = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", optional = true }
-bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", optional = true }
-bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", optional = true }
-bevy_shader = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", optional = true }
-bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", optional = true }
+bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", optional = true }
+bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", optional = true }
+bevy_image = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", features = ["zstd_rust"], optional = true }
+bevy_mesh = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", optional = true }
+bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", optional = true }
+bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", optional = true }
+bevy_shader = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", optional = true }
+bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", optional = true }
 encase = { version = "0.12", optional = true }
 itertools = { version = "0.14", optional = true }
 wgpu-types = { version = "28.0", optional = true }
 
 # `bevy_ui` feature
-bevy_ui_render = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", optional = true }
+bevy_ui_render = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", optional = true }
 
 # `picking` feature
-bevy_picking = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", optional = true, features = ["mesh_picking"] }
+bevy_picking = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", optional = true, features = ["mesh_picking"] }
 
 # `manage_clipboard` feature
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
@@ -131,7 +131,7 @@ thread_local = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9.5"
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", default-features = false, features = [
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", default-features = false, features = [
     "bevy_log",
     "bevy_asset",
     "bevy_core_pipeline",
@@ -159,7 +159,7 @@ bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", defaul
 egui = { version = "0.33", default-features = false, features = ["bytemuck"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", default-features = false, features = ["accesskit_unix"] }
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", default-features = false, features = ["accesskit_unix"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dev-dependencies]
 rfd = "0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ features = ["bevy_winit/x11", "immutable_ctx"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 default = ["manage_clipboard", "open_url", "default_fonts", "render", "bevy_ui", "picking"]
-accesskit = ["egui/accesskit", "bevy_a11y"]
+accesskit = ["bevy_a11y"]
 immutable_ctx = []
 manage_clipboard = ["arboard", "thread_local", "bytemuck", "egui/bytemuck"]
 open_url = ["webbrowser"]
@@ -83,7 +83,7 @@ name = "file_browse"
 required-features = ["render"]
 
 [dependencies]
-egui = { version = "0.33", default-features = false }
+egui = { version = "0.34", default-features = false }
 bevy_a11y = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", optional = true }
 bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
 bevy_camera = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
@@ -156,7 +156,7 @@ bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", defaul
     "x11",
     "zstd_rust"
 ] }
-egui = { version = "0.33", default-features = false, features = ["bytemuck"] }
+egui = { version = "0.34", default-features = false, features = ["bytemuck"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", default-features = false, features = ["accesskit_unix"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,20 +84,20 @@ required-features = ["render"]
 
 [dependencies]
 egui = { version = "0.34", default-features = false }
-bevy_a11y = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", optional = true }
-bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47" }
-bevy_camera = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47" }
-bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47" }
-bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47" }
-bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47" }
-bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47" }
-bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47" }
-bevy_platform = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47" }
-bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47" }
-bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47" }
-bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47" }
-bevy_winit = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47" }
-bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", features = ["debug"] }
+bevy_a11y = { version = "0.19.0-dev", optional = true }
+bevy_app = { version = "0.19.0-dev" }
+bevy_camera = { version = "0.19.0-dev" }
+bevy_derive = { version = "0.19.0-dev" }
+bevy_ecs = { version = "0.19.0-dev" }
+bevy_input = { version = "0.19.0-dev" }
+bevy_log = { version = "0.19.0-dev" }
+bevy_math = { version = "0.19.0-dev" }
+bevy_platform = { version = "0.19.0-dev" }
+bevy_reflect = { version = "0.19.0-dev" }
+bevy_time = { version = "0.19.0-dev" }
+bevy_window = { version = "0.19.0-dev" }
+bevy_winit = { version = "0.19.0-dev" }
+bevy_utils = { version = "0.19.0-dev", features = ["debug"] }
 winit = { version = "0.30", default-features = false }
 
 # `open_url` feature
@@ -106,23 +106,23 @@ webbrowser = { version = "1.0.1", optional = true }
 # `render` feature
 bytemuck = { version = "1", optional = true }
 
-bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", optional = true }
-bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", optional = true }
-bevy_image = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", features = ["zstd_rust"], optional = true }
-bevy_mesh = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", optional = true }
-bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", optional = true }
-bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", optional = true }
-bevy_shader = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", optional = true }
-bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", optional = true }
+bevy_asset = { version = "0.19.0-dev", optional = true }
+bevy_core_pipeline = { version = "0.19.0-dev", optional = true }
+bevy_image = { version = "0.19.0-dev", features = ["zstd_rust"], optional = true }
+bevy_mesh = { version = "0.19.0-dev", optional = true }
+bevy_render = { version = "0.19.0-dev", optional = true }
+bevy_color = { version = "0.19.0-dev", optional = true }
+bevy_shader = { version = "0.19.0-dev", optional = true }
+bevy_transform = { version = "0.19.0-dev", optional = true }
 encase = { version = "0.12", optional = true }
 itertools = { version = "0.14", optional = true }
 wgpu-types = { version = "29.0.1", optional = true }
 
 # `bevy_ui` feature
-bevy_ui_render = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", optional = true }
+bevy_ui_render = { version = "0.19.0-dev", optional = true }
 
 # `picking` feature
-bevy_picking = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", optional = true, features = ["mesh_picking"] }
+bevy_picking = { version = "0.19.0-dev", optional = true, features = ["mesh_picking"] }
 
 # `manage_clipboard` feature
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
@@ -131,7 +131,7 @@ thread_local = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9.5"
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", default-features = false, features = [
+bevy = { version = "0.19.0-dev", default-features = false, features = [
     "bevy_log",
     "bevy_asset",
     "bevy_core_pipeline",
@@ -159,7 +159,7 @@ bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", defaul
 egui = { version = "0.34", default-features = false, features = ["bytemuck"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", default-features = false, features = ["accesskit_unix"] }
+bevy = { version = "0.19.0-dev", default-features = false, features = ["accesskit_unix"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dev-dependencies]
 rfd = "0.17"
@@ -186,3 +186,30 @@ wasm-bindgen = "0.2.93"
 wasm-bindgen-futures = "0.4.36"
 crossbeam-channel = "0.5.8"
 getrandom = { version = "0.3", features = ["wasm_js"] }
+
+[patch."crates-io"]
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy_a11y = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy_camera = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy_platform = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy_winit = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy_image = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy_mesh = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy_shader = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy_picking = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }
+bevy_ui_render = { git = "https://github.com/bevyengine/bevy.git", rev = "fb7f58b" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,20 +84,20 @@ required-features = ["render"]
 
 [dependencies]
 egui = { version = "0.33", default-features = false }
-bevy_a11y = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", optional = true }
-bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194" }
-bevy_camera = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194" }
-bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194" }
-bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194" }
-bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194" }
-bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194" }
-bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194" }
-bevy_platform = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194" }
-bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194" }
-bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194" }
-bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194" }
-bevy_winit = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194" }
-bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", features = ["debug"] }
+bevy_a11y = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", optional = true }
+bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e" }
+bevy_camera = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e" }
+bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e" }
+bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e" }
+bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e" }
+bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e" }
+bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e" }
+bevy_platform = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e" }
+bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e" }
+bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e" }
+bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e" }
+bevy_winit = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e" }
+bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", features = ["debug"] }
 winit = { version = "0.30", default-features = false }
 
 # `open_url` feature
@@ -106,23 +106,23 @@ webbrowser = { version = "1.0.1", optional = true }
 # `render` feature
 bytemuck = { version = "1", optional = true }
 
-bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", optional = true }
-bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", optional = true }
-bevy_image = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", features = ["zstd_rust"], optional = true }
-bevy_mesh = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", optional = true }
-bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", optional = true }
-bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", optional = true }
-bevy_shader = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", optional = true }
-bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", optional = true }
+bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", optional = true }
+bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", optional = true }
+bevy_image = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", features = ["zstd_rust"], optional = true }
+bevy_mesh = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", optional = true }
+bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", optional = true }
+bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", optional = true }
+bevy_shader = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", optional = true }
+bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", optional = true }
 encase = { version = "0.12", optional = true }
 itertools = { version = "0.14", optional = true }
 wgpu-types = { version = "28.0", optional = true }
 
 # `bevy_ui` feature
-bevy_ui_render = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", optional = true }
+bevy_ui_render = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", optional = true }
 
 # `picking` feature
-bevy_picking = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", optional = true, features = ["mesh_picking"] }
+bevy_picking = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", optional = true, features = ["mesh_picking"] }
 
 # `manage_clipboard` feature
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
@@ -131,7 +131,7 @@ thread_local = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9.5"
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", default-features = false, features = [
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", default-features = false, features = [
     "bevy_log",
     "bevy_asset",
     "bevy_core_pipeline",
@@ -159,7 +159,7 @@ bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", defaul
 egui = { version = "0.33", default-features = false, features = ["bytemuck"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "2466194", default-features = false, features = ["accesskit_unix"] }
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", default-features = false, features = ["accesskit_unix"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dev-dependencies]
 rfd = "0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,20 +84,20 @@ required-features = ["render"]
 
 [dependencies]
 egui = { version = "0.33", default-features = false }
-bevy_a11y = { version = "0.19.0-dev", optional = true }
-bevy_app = { version = "0.19.0-dev" }
-bevy_camera = { version = "0.19.0-dev" }
-bevy_derive = { version = "0.19.0-dev" }
-bevy_ecs = { version = "0.19.0-dev" }
-bevy_input = { version = "0.19.0-dev" }
-bevy_log = { version = "0.19.0-dev" }
-bevy_math = { version = "0.19.0-dev" }
-bevy_platform = { version = "0.19.0-dev" }
-bevy_reflect = { version = "0.19.0-dev" }
-bevy_time = { version = "0.19.0-dev" }
-bevy_window = { version = "0.19.0-dev" }
-bevy_winit = { version = "0.19.0-dev" }
-bevy_utils = { version = "0.19.0-dev", features = ["debug"] }
+bevy_a11y = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", optional = true }
+bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_camera = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_platform = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_winit = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", features = ["debug"] }
 winit = { version = "0.30", default-features = false }
 
 # `open_url` feature
@@ -106,23 +106,23 @@ webbrowser = { version = "1.0.1", optional = true }
 # `render` feature
 bytemuck = { version = "1", optional = true }
 
-bevy_asset = { version = "0.19.0-dev", optional = true }
-bevy_core_pipeline = { version = "0.19.0-dev", optional = true }
-bevy_image = { version = "0.19.0-dev", features = ["zstd_rust"], optional = true }
-bevy_mesh = { version = "0.19.0-dev", optional = true }
-bevy_render = { version = "0.19.0-dev", optional = true }
-bevy_color = { version = "0.19.0-dev", optional = true }
-bevy_shader = { version = "0.19.0-dev", optional = true }
-bevy_transform = { version = "0.19.0-dev", optional = true }
+bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", optional = true }
+bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", optional = true }
+bevy_image = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", features = ["zstd_rust"], optional = true }
+bevy_mesh = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", optional = true }
+bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", optional = true }
+bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", optional = true }
+bevy_shader = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", optional = true }
+bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", optional = true }
 encase = { version = "0.12", optional = true }
 itertools = { version = "0.14", optional = true }
 wgpu-types = { version = "28.0", optional = true }
 
 # `bevy_ui` feature
-bevy_ui_render = { version = "0.19.0-dev", optional = true }
+bevy_ui_render = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", optional = true }
 
 # `picking` feature
-bevy_picking = { version = "0.19.0-dev", optional = true, features = ["mesh_picking"] }
+bevy_picking = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", optional = true, features = ["mesh_picking"] }
 
 # `manage_clipboard` feature
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
@@ -131,7 +131,7 @@ thread_local = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9.5"
-bevy = { version = "0.19.0-dev", default-features = false, features = [
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", default-features = false, features = [
     "bevy_log",
     "bevy_asset",
     "bevy_core_pipeline",
@@ -159,7 +159,7 @@ bevy = { version = "0.19.0-dev", default-features = false, features = [
 egui = { version = "0.33", default-features = false, features = ["bytemuck"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-bevy = { version = "0.19.0-dev", default-features = false, features = ["accesskit_unix"] }
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", default-features = false, features = ["accesskit_unix"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dev-dependencies]
 rfd = "0.17"
@@ -186,30 +186,3 @@ wasm-bindgen = "0.2.93"
 wasm-bindgen-futures = "0.4.36"
 crossbeam-channel = "0.5.8"
 getrandom = { version = "0.3", features = ["wasm_js"] }
-
-[patch."crates-io"]
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_a11y = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_camera = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_platform = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_winit = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_image = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_mesh = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_shader = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_picking = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_ui_render = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,20 +84,20 @@ required-features = ["render"]
 
 [dependencies]
 egui = { version = "0.34", default-features = false }
-bevy_a11y = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", optional = true }
-bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
-bevy_camera = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
-bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
-bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
-bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
-bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
-bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
-bevy_platform = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
-bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
-bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
-bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
-bevy_winit = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
-bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", features = ["debug"] }
+bevy_a11y = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", optional = true }
+bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89" }
+bevy_camera = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89" }
+bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89" }
+bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89" }
+bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89" }
+bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89" }
+bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89" }
+bevy_platform = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89" }
+bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89" }
+bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89" }
+bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89" }
+bevy_winit = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89" }
+bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", features = ["debug"] }
 winit = { version = "0.30", default-features = false }
 
 # `open_url` feature
@@ -106,23 +106,23 @@ webbrowser = { version = "1.0.1", optional = true }
 # `render` feature
 bytemuck = { version = "1", optional = true }
 
-bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", optional = true }
-bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", optional = true }
-bevy_image = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", features = ["zstd_rust"], optional = true }
-bevy_mesh = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", optional = true }
-bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", optional = true }
-bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", optional = true }
-bevy_shader = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", optional = true }
-bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", optional = true }
+bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", optional = true }
+bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", optional = true }
+bevy_image = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", features = ["zstd_rust"], optional = true }
+bevy_mesh = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", optional = true }
+bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", optional = true }
+bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", optional = true }
+bevy_shader = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", optional = true }
+bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", optional = true }
 encase = { version = "0.12", optional = true }
 itertools = { version = "0.14", optional = true }
 wgpu-types = { version = "29.0", optional = true }
 
 # `bevy_ui` feature
-bevy_ui_render = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", optional = true }
+bevy_ui_render = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", optional = true }
 
 # `picking` feature
-bevy_picking = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", optional = true, features = ["mesh_picking"] }
+bevy_picking = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", optional = true, features = ["mesh_picking"] }
 
 # `manage_clipboard` feature
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
@@ -131,7 +131,7 @@ thread_local = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9.5"
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", default-features = false, features = [
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", default-features = false, features = [
     "bevy_log",
     "bevy_asset",
     "bevy_core_pipeline",
@@ -159,7 +159,7 @@ bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", defaul
 egui = { version = "0.34", default-features = false, features = ["bytemuck"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", default-features = false, features = ["accesskit_unix"] }
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", default-features = false, features = ["accesskit_unix"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dev-dependencies]
 rfd = "0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,20 +84,20 @@ required-features = ["render"]
 
 [dependencies]
 egui = { version = "0.34", default-features = false }
-bevy_a11y = { version = "0.19.0-dev", optional = true }
-bevy_app = { version = "0.19.0-dev" }
-bevy_camera = { version = "0.19.0-dev" }
-bevy_derive = { version = "0.19.0-dev" }
-bevy_ecs = { version = "0.19.0-dev" }
-bevy_input = { version = "0.19.0-dev" }
-bevy_log = { version = "0.19.0-dev" }
-bevy_math = { version = "0.19.0-dev" }
-bevy_platform = { version = "0.19.0-dev" }
-bevy_reflect = { version = "0.19.0-dev" }
-bevy_time = { version = "0.19.0-dev" }
-bevy_window = { version = "0.19.0-dev" }
-bevy_winit = { version = "0.19.0-dev" }
-bevy_utils = { version = "0.19.0-dev", features = ["debug"] }
+bevy_a11y = { version = "0.19.0-rc.1", optional = true }
+bevy_app = { version = "0.19.0-rc.1" }
+bevy_camera = { version = "0.19.0-rc.1" }
+bevy_derive = { version = "0.19.0-rc.1" }
+bevy_ecs = { version = "0.19.0-rc.1" }
+bevy_input = { version = "0.19.0-rc.1" }
+bevy_log = { version = "0.19.0-rc.1" }
+bevy_math = { version = "0.19.0-rc.1" }
+bevy_platform = { version = "0.19.0-rc.1" }
+bevy_reflect = { version = "0.19.0-rc.1" }
+bevy_time = { version = "0.19.0-rc.1" }
+bevy_window = { version = "0.19.0-rc.1" }
+bevy_winit = { version = "0.19.0-rc.1" }
+bevy_utils = { version = "0.19.0-rc.1", features = ["debug"] }
 winit = { version = "0.30", default-features = false }
 
 # `open_url` feature
@@ -106,23 +106,23 @@ webbrowser = { version = "1.0.1", optional = true }
 # `render` feature
 bytemuck = { version = "1", optional = true }
 
-bevy_asset = { version = "0.19.0-dev", optional = true }
-bevy_core_pipeline = { version = "0.19.0-dev", optional = true }
-bevy_image = { version = "0.19.0-dev", features = ["zstd_rust"], optional = true }
-bevy_mesh = { version = "0.19.0-dev", optional = true }
-bevy_render = { version = "0.19.0-dev", optional = true }
-bevy_color = { version = "0.19.0-dev", optional = true }
-bevy_shader = { version = "0.19.0-dev", optional = true }
-bevy_transform = { version = "0.19.0-dev", optional = true }
+bevy_asset = { version = "0.19.0-rc.1", optional = true }
+bevy_core_pipeline = { version = "0.19.0-rc.1", optional = true }
+bevy_image = { version = "0.19.0-rc.1", features = ["zstd_rust"], optional = true }
+bevy_mesh = { version = "0.19.0-rc.1", optional = true }
+bevy_render = { version = "0.19.0-rc.1", optional = true }
+bevy_color = { version = "0.19.0-rc.1", optional = true }
+bevy_shader = { version = "0.19.0-rc.1", optional = true }
+bevy_transform = { version = "0.19.0-rc.1", optional = true }
 encase = { version = "0.12", optional = true }
 itertools = { version = "0.14", optional = true }
 wgpu-types = { version = "29.0.3", optional = true }
 
 # `bevy_ui` feature
-bevy_ui_render = { version = "0.19.0-dev", optional = true }
+bevy_ui_render = { version = "0.19.0-rc.1", optional = true }
 
 # `picking` feature
-bevy_picking = { version = "0.19.0-dev", optional = true, features = ["mesh_picking"] }
+bevy_picking = { version = "0.19.0-rc.1", optional = true, features = ["mesh_picking"] }
 
 # `manage_clipboard` feature
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
@@ -131,7 +131,7 @@ thread_local = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9.5"
-bevy = { version = "0.19.0-dev", default-features = false, features = [
+bevy = { version = "0.19.0-rc.1", default-features = false, features = [
     "bevy_log",
     "bevy_asset",
     "bevy_core_pipeline",
@@ -159,7 +159,7 @@ bevy = { version = "0.19.0-dev", default-features = false, features = [
 egui = { version = "0.34", default-features = false, features = ["bytemuck"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-bevy = { version = "0.19.0-dev", default-features = false, features = ["accesskit_unix"] }
+bevy = { version = "0.19.0-rc.1", default-features = false, features = ["accesskit_unix"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dev-dependencies]
 rfd = "0.17"
@@ -186,30 +186,3 @@ wasm-bindgen = "0.2.93"
 wasm-bindgen-futures = "0.4.36"
 crossbeam-channel = "0.5.8"
 getrandom = { version = "0.3", features = ["wasm_js"] }
-
-[patch."crates-io"]
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
-bevy_a11y = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
-bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
-bevy_camera = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
-bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
-bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
-bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
-bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
-bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
-bevy_platform = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
-bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
-bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
-bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
-bevy_winit = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
-bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
-bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
-bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
-bevy_image = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
-bevy_mesh = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
-bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
-bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
-bevy_shader = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
-bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
-bevy_picking = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }
-bevy_ui_render = { git = "https://github.com/bevyengine/bevy.git", rev = "9bd7e1f" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_egui"
 version = "0.39.1"
-rust-version = "1.95.5"
+rust-version = "1.95.0"
 authors = ["vladbat00 <vladyslav.batyrenko@gmail.com>"]
 description = "A plugin for Egui integration into Bevy"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,20 +84,20 @@ required-features = ["render"]
 
 [dependencies]
 egui = { version = "0.34", default-features = false }
-bevy_a11y = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", optional = true }
-bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89" }
-bevy_camera = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89" }
-bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89" }
-bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89" }
-bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89" }
-bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89" }
-bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89" }
-bevy_platform = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89" }
-bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89" }
-bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89" }
-bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89" }
-bevy_winit = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89" }
-bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", features = ["debug"] }
+bevy_a11y = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", optional = true }
+bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9" }
+bevy_camera = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9" }
+bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9" }
+bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9" }
+bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9" }
+bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9" }
+bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9" }
+bevy_platform = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9" }
+bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9" }
+bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9" }
+bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9" }
+bevy_winit = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9" }
+bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", features = ["debug"] }
 winit = { version = "0.30", default-features = false }
 
 # `open_url` feature
@@ -106,23 +106,23 @@ webbrowser = { version = "1.0.1", optional = true }
 # `render` feature
 bytemuck = { version = "1", optional = true }
 
-bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", optional = true }
-bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", optional = true }
-bevy_image = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", features = ["zstd_rust"], optional = true }
-bevy_mesh = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", optional = true }
-bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", optional = true }
-bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", optional = true }
-bevy_shader = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", optional = true }
-bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", optional = true }
+bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", optional = true }
+bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", optional = true }
+bevy_image = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", features = ["zstd_rust"], optional = true }
+bevy_mesh = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", optional = true }
+bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", optional = true }
+bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", optional = true }
+bevy_shader = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", optional = true }
+bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", optional = true }
 encase = { version = "0.12", optional = true }
 itertools = { version = "0.14", optional = true }
 wgpu-types = { version = "29.0", optional = true }
 
 # `bevy_ui` feature
-bevy_ui_render = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", optional = true }
+bevy_ui_render = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", optional = true }
 
 # `picking` feature
-bevy_picking = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", optional = true, features = ["mesh_picking"] }
+bevy_picking = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", optional = true, features = ["mesh_picking"] }
 
 # `manage_clipboard` feature
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
@@ -131,7 +131,7 @@ thread_local = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9.5"
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", default-features = false, features = [
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", default-features = false, features = [
     "bevy_log",
     "bevy_asset",
     "bevy_core_pipeline",
@@ -159,7 +159,7 @@ bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", defaul
 egui = { version = "0.34", default-features = false, features = ["bytemuck"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "ed86a89", default-features = false, features = ["accesskit_unix"] }
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", default-features = false, features = ["accesskit_unix"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dev-dependencies]
 rfd = "0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,20 +84,20 @@ required-features = ["render"]
 
 [dependencies]
 egui = { version = "0.33", default-features = false }
-bevy_a11y = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", optional = true }
-bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e" }
-bevy_camera = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e" }
-bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e" }
-bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e" }
-bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e" }
-bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e" }
-bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e" }
-bevy_platform = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e" }
-bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e" }
-bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e" }
-bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e" }
-bevy_winit = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e" }
-bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", features = ["debug"] }
+bevy_a11y = { version = "0.19.0-dev", optional = true }
+bevy_app = { version = "0.19.0-dev" }
+bevy_camera = { version = "0.19.0-dev" }
+bevy_derive = { version = "0.19.0-dev" }
+bevy_ecs = { version = "0.19.0-dev" }
+bevy_input = { version = "0.19.0-dev" }
+bevy_log = { version = "0.19.0-dev" }
+bevy_math = { version = "0.19.0-dev" }
+bevy_platform = { version = "0.19.0-dev" }
+bevy_reflect = { version = "0.19.0-dev" }
+bevy_time = { version = "0.19.0-dev" }
+bevy_window = { version = "0.19.0-dev" }
+bevy_winit = { version = "0.19.0-dev" }
+bevy_utils = { version = "0.19.0-dev", features = ["debug"] }
 winit = { version = "0.30", default-features = false }
 
 # `open_url` feature
@@ -106,23 +106,23 @@ webbrowser = { version = "1.0.1", optional = true }
 # `render` feature
 bytemuck = { version = "1", optional = true }
 
-bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", optional = true }
-bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", optional = true }
-bevy_image = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", features = ["zstd_rust"], optional = true }
-bevy_mesh = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", optional = true }
-bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", optional = true }
-bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", optional = true }
-bevy_shader = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", optional = true }
-bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", optional = true }
+bevy_asset = { version = "0.19.0-dev", optional = true }
+bevy_core_pipeline = { version = "0.19.0-dev", optional = true }
+bevy_image = { version = "0.19.0-dev", features = ["zstd_rust"], optional = true }
+bevy_mesh = { version = "0.19.0-dev", optional = true }
+bevy_render = { version = "0.19.0-dev", optional = true }
+bevy_color = { version = "0.19.0-dev", optional = true }
+bevy_shader = { version = "0.19.0-dev", optional = true }
+bevy_transform = { version = "0.19.0-dev", optional = true }
 encase = { version = "0.12", optional = true }
 itertools = { version = "0.14", optional = true }
 wgpu-types = { version = "28.0", optional = true }
 
 # `bevy_ui` feature
-bevy_ui_render = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", optional = true }
+bevy_ui_render = { version = "0.19.0-dev", optional = true }
 
 # `picking` feature
-bevy_picking = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", optional = true, features = ["mesh_picking"] }
+bevy_picking = { version = "0.19.0-dev", optional = true, features = ["mesh_picking"] }
 
 # `manage_clipboard` feature
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
@@ -131,7 +131,7 @@ thread_local = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9.5"
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", default-features = false, features = [
+bevy = { version = "0.19.0-dev", default-features = false, features = [
     "bevy_log",
     "bevy_asset",
     "bevy_core_pipeline",
@@ -159,7 +159,7 @@ bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", defaul
 egui = { version = "0.33", default-features = false, features = ["bytemuck"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "71cfd3e", default-features = false, features = ["accesskit_unix"] }
+bevy = { version = "0.19.0-dev", default-features = false, features = ["accesskit_unix"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dev-dependencies]
 rfd = "0.17"
@@ -186,3 +186,30 @@ wasm-bindgen = "0.2.93"
 wasm-bindgen-futures = "0.4.36"
 crossbeam-channel = "0.5.8"
 getrandom = { version = "0.3", features = ["wasm_js"] }
+
+[patch."crates-io"]
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_a11y = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_camera = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_platform = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_winit = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_image = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_mesh = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_shader = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_picking = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
+bevy_ui_render = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,8 +88,8 @@ bevy_a11y = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", o
 bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
 bevy_camera = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
 bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
-bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e"}
-bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e"}
+bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
+bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
 bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
 bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
 bevy_platform = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
@@ -135,11 +135,13 @@ bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", defaul
     "bevy_log",
     "bevy_asset",
     "bevy_core_pipeline",
+    "bevy_gizmos",
     "bevy_pbr",
     "mesh_picking",
     "bevy_sprite",
     "bevy_sprite_render",
     "bevy_text",
+    "bevy_ui_render",
     "bevy_window",
     "bevy_winit",
     "mouse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ bevy_shader = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e",
 bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", optional = true }
 encase = { version = "0.12", optional = true }
 itertools = { version = "0.14", optional = true }
-wgpu-types = { version = "27.0", optional = true }
+wgpu-types = { version = "28.0", optional = true }
 
 # `bevy_ui` feature
 bevy_ui_render = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,20 +84,20 @@ required-features = ["render"]
 
 [dependencies]
 egui = { version = "0.33", default-features = false }
-bevy_a11y = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", optional = true }
-bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_camera = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_platform = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_winit = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36" }
-bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", features = ["debug"] }
+bevy_a11y = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", optional = true }
+bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
+bevy_camera = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
+bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
+bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
+bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
+bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
+bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
+bevy_platform = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
+bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
+bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
+bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
+bevy_winit = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6" }
+bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", features = ["debug"] }
 winit = { version = "0.30", default-features = false }
 
 # `open_url` feature
@@ -106,23 +106,23 @@ webbrowser = { version = "1.0.1", optional = true }
 # `render` feature
 bytemuck = { version = "1", optional = true }
 
-bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", optional = true }
-bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", optional = true }
-bevy_image = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", features = ["zstd_rust"], optional = true }
-bevy_mesh = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", optional = true }
-bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", optional = true }
-bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", optional = true }
-bevy_shader = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", optional = true }
-bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", optional = true }
+bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", optional = true }
+bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", optional = true }
+bevy_image = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", features = ["zstd_rust"], optional = true }
+bevy_mesh = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", optional = true }
+bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", optional = true }
+bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", optional = true }
+bevy_shader = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", optional = true }
+bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", optional = true }
 encase = { version = "0.12", optional = true }
 itertools = { version = "0.14", optional = true }
-wgpu-types = { version = "28.0", optional = true }
+wgpu-types = { version = "29.0", optional = true }
 
 # `bevy_ui` feature
-bevy_ui_render = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", optional = true }
+bevy_ui_render = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", optional = true }
 
 # `picking` feature
-bevy_picking = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", optional = true, features = ["mesh_picking"] }
+bevy_picking = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", optional = true, features = ["mesh_picking"] }
 
 # `manage_clipboard` feature
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
@@ -131,7 +131,7 @@ thread_local = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9.5"
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", default-features = false, features = [
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", default-features = false, features = [
     "bevy_log",
     "bevy_asset",
     "bevy_core_pipeline",
@@ -159,7 +159,7 @@ bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", defaul
 egui = { version = "0.33", default-features = false, features = ["bytemuck"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "888ab36", default-features = false, features = ["accesskit_unix"] }
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "f1f57f6", default-features = false, features = ["accesskit_unix"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dev-dependencies]
 rfd = "0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_egui"
 version = "0.39.1"
-rust-version = "1.89.0"
+rust-version = "1.95.5"
 authors = ["vladbat00 <vladyslav.batyrenko@gmail.com>"]
 description = "A plugin for Egui integration into Bevy"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,20 +84,20 @@ required-features = ["render"]
 
 [dependencies]
 egui = { version = "0.33", default-features = false }
-bevy_a11y = { version = "0.18.0", optional = true }
-bevy_app = { version = "0.18.0" }
-bevy_camera = { version = "0.18.0" }
-bevy_derive = { version = "0.18.0" }
-bevy_ecs = { version = "0.18.0" }
-bevy_input = { version = "0.18.0" }
-bevy_log = { version = "0.18.0" }
-bevy_math = { version = "0.18.0" }
-bevy_platform = { version = "0.18.0" }
-bevy_reflect = { version = "0.18.0" }
-bevy_time = { version = "0.18.0" }
-bevy_window = { version = "0.18.0" }
-bevy_winit = { version = "0.18.0" }
-bevy_utils = { version = "0.18.0", features = ["debug"] }
+bevy_a11y = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", optional = true }
+bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
+bevy_camera = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
+bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
+bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e"}
+bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e"}
+bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
+bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
+bevy_platform = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
+bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
+bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
+bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
+bevy_winit = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e" }
+bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", features = ["debug"] }
 winit = { version = "0.30", default-features = false }
 
 # `open_url` feature
@@ -106,23 +106,23 @@ webbrowser = { version = "1.0.1", optional = true }
 # `render` feature
 bytemuck = { version = "1", optional = true }
 
-bevy_asset = { version = "0.18.0", optional = true }
-bevy_core_pipeline = { version = "0.18.0", optional = true }
-bevy_image = { version = "0.18.0", features = ["zstd_rust"], optional = true }
-bevy_mesh = { version = "0.18.0", optional = true }
-bevy_render = { version = "0.18.0", optional = true }
-bevy_color = { version = "0.18.0", optional = true }
-bevy_shader = { version = "0.18.0", optional = true }
-bevy_transform = { version = "0.18.0", optional = true }
+bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", optional = true }
+bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", optional = true }
+bevy_image = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", features = ["zstd_rust"], optional = true }
+bevy_mesh = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", optional = true }
+bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", optional = true }
+bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", optional = true }
+bevy_shader = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", optional = true }
+bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", optional = true }
 encase = { version = "0.12", optional = true }
 itertools = { version = "0.14", optional = true }
 wgpu-types = { version = "27.0", optional = true }
 
 # `bevy_ui` feature
-bevy_ui_render = { version = "0.18.0", optional = true }
+bevy_ui_render = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", optional = true }
 
 # `picking` feature
-bevy_picking = { version = "0.18.0", optional = true, features = ["mesh_picking"] }
+bevy_picking = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", optional = true, features = ["mesh_picking"] }
 
 # `manage_clipboard` feature
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
@@ -131,7 +131,7 @@ thread_local = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9.5"
-bevy = { version = "0.18.0", default-features = false, features = [
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", default-features = false, features = [
     "bevy_log",
     "bevy_asset",
     "bevy_core_pipeline",
@@ -157,7 +157,7 @@ bevy = { version = "0.18.0", default-features = false, features = [
 egui = { version = "0.33", default-features = false, features = ["bytemuck"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-bevy = { version = "0.18.0", default-features = false, features = ["accesskit_unix"] }
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "1b3b01e", default-features = false, features = ["accesskit_unix"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dev-dependencies]
 rfd = "0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,20 +84,20 @@ required-features = ["render"]
 
 [dependencies]
 egui = { version = "0.34", default-features = false }
-bevy_a11y = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", optional = true }
-bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9" }
-bevy_camera = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9" }
-bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9" }
-bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9" }
-bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9" }
-bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9" }
-bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9" }
-bevy_platform = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9" }
-bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9" }
-bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9" }
-bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9" }
-bevy_winit = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9" }
-bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", features = ["debug"] }
+bevy_a11y = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", optional = true }
+bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47" }
+bevy_camera = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47" }
+bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47" }
+bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47" }
+bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47" }
+bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47" }
+bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47" }
+bevy_platform = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47" }
+bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47" }
+bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47" }
+bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47" }
+bevy_winit = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47" }
+bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", features = ["debug"] }
 winit = { version = "0.30", default-features = false }
 
 # `open_url` feature
@@ -106,23 +106,23 @@ webbrowser = { version = "1.0.1", optional = true }
 # `render` feature
 bytemuck = { version = "1", optional = true }
 
-bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", optional = true }
-bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", optional = true }
-bevy_image = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", features = ["zstd_rust"], optional = true }
-bevy_mesh = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", optional = true }
-bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", optional = true }
-bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", optional = true }
-bevy_shader = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", optional = true }
-bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", optional = true }
+bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", optional = true }
+bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", optional = true }
+bevy_image = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", features = ["zstd_rust"], optional = true }
+bevy_mesh = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", optional = true }
+bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", optional = true }
+bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", optional = true }
+bevy_shader = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", optional = true }
+bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", optional = true }
 encase = { version = "0.12", optional = true }
 itertools = { version = "0.14", optional = true }
-wgpu-types = { version = "29.0", optional = true }
+wgpu-types = { version = "29.0.1", optional = true }
 
 # `bevy_ui` feature
-bevy_ui_render = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", optional = true }
+bevy_ui_render = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", optional = true }
 
 # `picking` feature
-bevy_picking = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", optional = true, features = ["mesh_picking"] }
+bevy_picking = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", optional = true, features = ["mesh_picking"] }
 
 # `manage_clipboard` feature
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
@@ -131,7 +131,7 @@ thread_local = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9.5"
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", default-features = false, features = [
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", default-features = false, features = [
     "bevy_log",
     "bevy_asset",
     "bevy_core_pipeline",
@@ -159,7 +159,7 @@ bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", defaul
 egui = { version = "0.34", default-features = false, features = ["bytemuck"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9", default-features = false, features = ["accesskit_unix"] }
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "d06aa47", default-features = false, features = ["accesskit_unix"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dev-dependencies]
 rfd = "0.17"

--- a/examples/color_test.rs
+++ b/examples/color_test.rs
@@ -226,8 +226,17 @@ fn ui_system(
     images: Res<Assets<bevy::image::Image>>,
 ) -> Result {
     let ctx = contexts.ctx_mut()?;
-    app_state.top_panel_height = egui::TopBottomPanel::top("top_panel")
-        .show(ctx, |ui| {
+    let viewport_rect = ctx.viewport_rect();
+    let mut viewport_ui = Ui::new(
+        ctx.clone(),
+        "viewport".into(),
+        UiBuilder::new()
+            .layer_id(LayerId::background())
+            .max_rect(viewport_rect),
+    );
+
+    app_state.top_panel_height = egui::Panel::top("top_panel")
+        .show_inside(&mut viewport_ui, |ui| {
             ui.horizontal(|ui| {
                 ui.selectable_value(
                     &mut app_state.displayed_ui,
@@ -252,7 +261,7 @@ fn ui_system(
 
     match app_state.displayed_ui {
         DisplayedUi::Regular => {
-            egui::CentralPanel::default().show(ctx, |ui| {
+            egui::CentralPanel::default().show_inside(&mut viewport_ui, |ui| {
                 egui::ScrollArea::vertical().show(ui, |ui| {
                     app_state.color_test.ui(ui);
                 });
@@ -265,7 +274,7 @@ fn ui_system(
                 .expect("Expected a created image");
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ctx, |ui| {
+                .show_inside(&mut viewport_ui, |ui| {
                     ui.image(egui::load::SizedTexture::new(
                         app_state.egui_texture_image_id,
                         [
@@ -284,7 +293,16 @@ fn render_to_image_ui_system<C: Component>(
     mut app_state: ResMut<AppState>,
     mut context: Single<&mut EguiContext, With<C>>,
 ) {
-    egui::CentralPanel::default().show(context.get_mut(), |ui| {
+    let ctx = context.get_mut();
+    let viewport_rect = ctx.viewport_rect();
+    let mut viewport_ui = Ui::new(
+        ctx.clone(),
+        "viewport".into(),
+        UiBuilder::new()
+            .layer_id(LayerId::background())
+            .max_rect(viewport_rect),
+    );
+    egui::CentralPanel::default().show_inside(&mut viewport_ui, |ui| {
         egui::ScrollArea::vertical().show(ui, |ui| {
             app_state.color_test.ui(ui);
         });
@@ -298,9 +316,9 @@ fn render_to_image_ui_system<C: Component>(
 use bevy_camera::RenderTarget;
 use bevy_ecs::schedule::ScheduleLabel;
 use egui::{
-    Align2, Color32, FontId, Image, Mesh, Pos2, Rect, Response, Rgba, RichText, Sense, Shape,
-    Stroke, TextureHandle, TextureOptions, Ui, Vec2, emath::GuiRounding, epaint, lerp, pos2, vec2,
-    widgets::color_picker::show_color,
+    Align2, Color32, FontId, Image, LayerId, Mesh, Pos2, Rect, Response, Rgba, RichText, Sense,
+    Shape, Stroke, TextureHandle, TextureOptions, Ui, UiBuilder, Vec2, emath::GuiRounding, epaint,
+    lerp, pos2, vec2, widgets::color_picker::show_color,
 };
 use std::collections::HashMap;
 use wgpu_types::{Extent3d, TextureUsages};

--- a/examples/color_test.rs
+++ b/examples/color_test.rs
@@ -226,13 +226,12 @@ fn ui_system(
     images: Res<Assets<bevy::image::Image>>,
 ) -> Result {
     let ctx = contexts.ctx_mut()?;
-    let viewport_rect = ctx.viewport_rect();
     let mut viewport_ui = Ui::new(
         ctx.clone(),
         "viewport".into(),
         UiBuilder::new()
             .layer_id(LayerId::background())
-            .max_rect(viewport_rect),
+            .max_rect(ctx.viewport_rect()),
     );
 
     app_state.top_panel_height = egui::Panel::top("top_panel")
@@ -294,13 +293,12 @@ fn render_to_image_ui_system<C: Component>(
     mut context: Single<&mut EguiContext, With<C>>,
 ) {
     let ctx = context.get_mut();
-    let viewport_rect = ctx.viewport_rect();
     let mut viewport_ui = Ui::new(
         ctx.clone(),
         "viewport".into(),
         UiBuilder::new()
             .layer_id(LayerId::background())
-            .max_rect(viewport_rect),
+            .max_rect(ctx.viewport_rect()),
     );
     egui::CentralPanel::default().show_inside(&mut viewport_ui, |ui| {
         egui::ScrollArea::vertical().show(ui, |ui| {

--- a/examples/color_test.rs
+++ b/examples/color_test.rs
@@ -164,15 +164,16 @@ fn update_image_size_system(
         let mut image = images
             .get_mut(image_handle)
             .expect("Expected a created image");
-        (image.data.as_mut().expect("image data"))
-            .resize((window.physical_width() * new_height * 4) as usize, 0);
-        image.texture_descriptor.size.width = window.physical_width();
-        image.texture_descriptor.size.height = new_height;
+        image.resize(Extent3d {
+            width: window.physical_width(),
+            height: new_height,
+            depth_or_array_layers: 1,
+        });
     }
 
     let (mesh_handle, material, mut transform) = egui_mesh.into_inner();
     // Mark the material as dirty for change detection to react to the image update.
-    materials.get_mut(material.id()).unwrap();
+    materials.get_mut(material.id()).unwrap().deref_mut();
     *meshes
         .get_mut(mesh_handle)
         .expect("Expected a created mesh") =
@@ -318,7 +319,7 @@ use egui::{
     Shape, Stroke, TextureHandle, TextureOptions, Ui, UiBuilder, Vec2, emath::GuiRounding, epaint,
     lerp, pos2, vec2, widgets::color_picker::show_color,
 };
-use std::collections::HashMap;
+use std::{collections::HashMap, ops::DerefMut};
 use wgpu_types::{Extent3d, TextureUsages};
 
 const GRADIENT_SIZE: Vec2 = vec2(256.0, 18.0);

--- a/examples/color_test.rs
+++ b/examples/color_test.rs
@@ -161,7 +161,7 @@ fn update_image_size_system(
             continue;
         };
 
-        let image = images
+        let mut image = images
             .get_mut(image_handle)
             .expect("Expected a created image");
         (image.data.as_mut().expect("image data"))

--- a/examples/color_test.rs
+++ b/examples/color_test.rs
@@ -939,7 +939,9 @@ fn paint_fine_lines_and_text(painter: &egui::Painter, mut rect: Rect, color: Col
     rect.max.x = rect.center().x;
 
     rect = rect.shrink(16.0);
-    for width in [0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 4.0] {
+    for width in [
+        0.05_f32, 0.1_f32, 0.25_f32, 0.5_f32, 1.0_f32, 2.0_f32, 4.0_f32,
+    ] {
         painter.text(
             rect.left_top(),
             Align2::CENTER_CENTER,

--- a/examples/file_browse.rs
+++ b/examples/file_browse.rs
@@ -38,13 +38,12 @@ mod foo {
         mut file_dialog: Local<Option<Task<DialogResponse>>>,
     ) -> Result {
         let ctx = contexts.ctx_mut()?;
-        let viewport_rect = ctx.viewport_rect();
         let mut viewport_ui = Ui::new(
             ctx.clone(),
             "viewport".into(),
             UiBuilder::new()
                 .layer_id(LayerId::background())
-                .max_rect(viewport_rect),
+                .max_rect(ctx.viewport_rect()),
         );
         egui::CentralPanel::default().show_inside(&mut viewport_ui, |ui| {
             ui.label("Drag-and-drop files onto the window!");

--- a/examples/file_browse.rs
+++ b/examples/file_browse.rs
@@ -21,6 +21,7 @@ mod foo {
         tasks::{AsyncComputeTaskPool, Task, block_on, poll_once},
     };
     use bevy_egui::{EguiContexts, egui};
+    use egui::{LayerId, Ui, UiBuilder};
 
     #[derive(Default)]
     pub struct MyState {
@@ -37,7 +38,15 @@ mod foo {
         mut file_dialog: Local<Option<Task<DialogResponse>>>,
     ) -> Result {
         let ctx = contexts.ctx_mut()?;
-        egui::CentralPanel::default().show(ctx, |ui| {
+        let viewport_rect = ctx.viewport_rect();
+        let mut viewport_ui = Ui::new(
+            ctx.clone(),
+            "viewport".into(),
+            UiBuilder::new()
+                .layer_id(LayerId::background())
+                .max_rect(viewport_rect),
+        );
+        egui::CentralPanel::default().show_inside(&mut viewport_ui, |ui| {
             ui.label("Drag-and-drop files onto the window!");
 
             if let Some(file_response) = file_dialog
@@ -138,7 +147,7 @@ mod foo {
                 content_rect.center(),
                 Align2::CENTER_CENTER,
                 text,
-                TextStyle::Heading.resolve(&ctx.style()),
+                TextStyle::Heading.resolve(&ctx.global_style()),
                 Color32::WHITE,
             );
         }

--- a/examples/paint_callback.rs
+++ b/examples/paint_callback.rs
@@ -138,7 +138,7 @@ impl SpecializedRenderPipeline for CustomPipeline {
         RenderPipelineDescriptor {
             label: Some("custom pipeline".into()),
             layout: vec![],
-            push_constant_ranges: Vec::new(),
+            immediate_size: 0,
             vertex: bevy::render::render_resource::VertexState {
                 shader: self.shader.clone(),
                 shader_defs: vec![],

--- a/examples/paint_callback.rs
+++ b/examples/paint_callback.rs
@@ -161,11 +161,7 @@ impl SpecializedRenderPipeline for CustomPipeline {
                 shader_defs: vec![],
                 entry_point: Some("fragment".into()),
                 targets: vec![Some(ColorTargetState {
-                    format: if key.hdr {
-                        ViewTarget::TEXTURE_FORMAT_HDR
-                    } else {
-                        TextureFormat::bevy_default()
-                    },
+                    format: key.target_format,
                     blend: Some(BlendState::ALPHA_BLENDING),
                     write_mask: ColorWrites::ALL,
                 })],

--- a/examples/paint_callback.rs
+++ b/examples/paint_callback.rs
@@ -19,9 +19,8 @@ use bevy_egui::{
     PrimaryEguiContext,
     render::{EguiBevyPaintCallback, EguiBevyPaintCallbackImpl, EguiPipelineKey},
 };
-use bevy_render::view::ViewTarget;
 use std::path::Path;
-use wgpu_types::{Extent3d, TextureFormat, TextureUsages};
+use wgpu_types::{Extent3d, TextureUsages};
 
 fn main() {
     App::new()

--- a/examples/render_egui_to_image.rs
+++ b/examples/render_egui_to_image.rs
@@ -209,7 +209,7 @@ fn handle_drag_system(
     >,
     mut mesh_egui_context: Single<&mut EguiContext, Without<PrimaryEguiContext>>,
 ) {
-    if mesh_egui_context.get_mut().wants_pointer_input() {
+    if mesh_egui_context.get_mut().egui_wants_pointer_input() {
         return;
     }
 

--- a/examples/render_to_image_widget.rs
+++ b/examples/render_to_image_widget.rs
@@ -155,7 +155,7 @@ fn render_to_image_example_system(
 ) -> Result {
     let cube_preview_texture_id = contexts.image_id(&**cube_preview_image).unwrap();
     let preview_material_handle = preview_cube_query.single()?;
-    let preview_material = materials.get_mut(preview_material_handle).unwrap();
+    let mut preview_material = materials.get_mut(preview_material_handle).unwrap();
 
     let ctx = contexts.ctx_mut()?;
     let mut apply = false;
@@ -192,7 +192,7 @@ fn render_to_image_example_system(
     });
 
     if apply {
-        let material_clone = preview_material.clone();
+        let material_clone = preview_material.into_inner().clone();
 
         let main_material_handle = main_cube_query.single()?;
         materials.insert(main_material_handle, material_clone)?;

--- a/examples/run_manually.rs
+++ b/examples/run_manually.rs
@@ -33,8 +33,8 @@ fn ui_example_system(
 ) -> Result {
     let (mut ctx, mut egui_input, mut egui_full_output) = contexts.single_mut()?;
 
-    let ui = |ctx: &egui::Context| {
-        egui::Window::new("Hello").show(ctx, |ui| {
+    let ui = |ui: &mut egui::Ui| {
+        egui::Window::new("Hello").show(ui, |ui| {
             let passes = ui
                 .ctx()
                 .viewport(|viewport| viewport.output.num_completed_passes)
@@ -49,7 +49,7 @@ fn ui_example_system(
         memory.options.max_passes = NonZero::new(5).unwrap();
     });
 
-    **egui_full_output = Some(ctx.run(egui_input.take(), ui));
+    **egui_full_output = Some(ctx.run_ui(egui_input.take(), ui));
 
     Ok(())
 }

--- a/examples/side_panel.rs
+++ b/examples/side_panel.rs
@@ -7,6 +7,7 @@ use bevy_egui::{
     EguiContext, EguiContexts, EguiGlobalSettings, EguiPlugin, EguiPrimaryContextPass,
     PrimaryEguiContext, egui,
 };
+use egui::{LayerId, Ui, UiBuilder};
 use wgpu_types::BlendState;
 
 fn main() {
@@ -28,10 +29,18 @@ fn ui_example_system(
     window: Single<&mut Window, With<PrimaryWindow>>,
 ) -> Result {
     let ctx = contexts.ctx_mut()?;
+    let viewport_rect = ctx.viewport_rect();
+    let mut viewport_ui = Ui::new(
+        ctx.clone(),
+        "viewport".into(),
+        UiBuilder::new()
+            .layer_id(LayerId::background())
+            .max_rect(viewport_rect),
+    );
 
-    let mut left = egui::SidePanel::left("left_panel")
+    let mut left = egui::Panel::left("left_panel")
         .resizable(true)
-        .show(ctx, |ui| {
+        .show_inside(&mut viewport_ui, |ui| {
             ui.label("Left resizeable panel");
             ui.allocate_rect(ui.available_rect_before_wrap(), egui::Sense::hover());
         })
@@ -39,9 +48,9 @@ fn ui_example_system(
         .rect
         .width(); // height is ignored, as the panel has a hight of 100% of the screen
 
-    let mut right = egui::SidePanel::right("right_panel")
+    let mut right = egui::Panel::right("right_panel")
         .resizable(true)
-        .show(ctx, |ui| {
+        .show_inside(&mut viewport_ui, |ui| {
             ui.label("Right resizeable panel");
             ui.allocate_rect(ui.available_rect_before_wrap(), egui::Sense::hover());
         })
@@ -49,18 +58,18 @@ fn ui_example_system(
         .rect
         .width(); // height is ignored, as the panel has a height of 100% of the screen
 
-    let mut top = egui::TopBottomPanel::top("top_panel")
+    let mut top = egui::Panel::top("top_panel")
         .resizable(true)
-        .show(ctx, |ui| {
+        .show_inside(&mut viewport_ui, |ui| {
             ui.label("Top resizeable panel");
             ui.allocate_rect(ui.available_rect_before_wrap(), egui::Sense::hover());
         })
         .response
         .rect
         .height(); // width is ignored, as the panel has a width of 100% of the screen
-    let mut bottom = egui::TopBottomPanel::bottom("bottom_panel")
+    let mut bottom = egui::Panel::bottom("bottom_panel")
         .resizable(true)
-        .show(ctx, |ui| {
+        .show_inside(&mut viewport_ui, |ui| {
             ui.label("Bottom resizeable panel");
             ui.allocate_rect(ui.available_rect_before_wrap(), egui::Sense::hover());
         })

--- a/examples/side_panel.rs
+++ b/examples/side_panel.rs
@@ -29,13 +29,12 @@ fn ui_example_system(
     window: Single<&mut Window, With<PrimaryWindow>>,
 ) -> Result {
     let ctx = contexts.ctx_mut()?;
-    let viewport_rect = ctx.viewport_rect();
     let mut viewport_ui = Ui::new(
         ctx.clone(),
         "viewport".into(),
         UiBuilder::new()
             .layer_id(LayerId::background())
-            .max_rect(viewport_rect),
+            .max_rect(ctx.viewport_rect()),
     );
 
     let mut left = egui::Panel::left("left_panel")

--- a/examples/split_screen.rs
+++ b/examples/split_screen.rs
@@ -61,7 +61,7 @@ fn setup_system(
     // Light.
     commands.spawn((
         PointLight {
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform::from_xyz(4.0, 8.0, 4.0),

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -6,7 +6,6 @@ use bevy_egui::{
     EguiContextSettings, EguiContexts, EguiPlugin, EguiPrimaryContextPass, EguiStartupSet,
     EguiTextureHandle,
 };
-use egui::{LayerId, Ui, UiBuilder};
 
 #[derive(Resource)]
 struct Images {
@@ -157,13 +156,12 @@ fn ui_example_system(
     }
 
     let ctx = contexts.ctx_mut()?;
-    let viewport_rect = ctx.viewport_rect();
-    let mut viewport_ui = Ui::new(
+    let mut viewport_ui = egui::Ui::new(
         ctx.clone(),
         "viewport".into(),
-        UiBuilder::new()
-            .layer_id(LayerId::background())
-            .max_rect(viewport_rect),
+        egui::UiBuilder::new()
+            .layer_id(egui::LayerId::background())
+            .max_rect(ctx.viewport_rect()),
     );
 
     let egui_texture_handle = ui_state

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -78,7 +78,7 @@ fn premultiply_alpha_for_images_system(
         if let AssetEvent::LoadedWithDependencies { id } = asset_event
             && (*id == images.bevy_icon.id() || *id == images.bevy_icon_inverted.id())
         {
-            let image = assets.get_mut(*id).expect("should have loaded image");
+            let mut image = assets.get_mut(*id).expect("should have loaded image");
             for x in 0..image.width() {
                 for y in 0..image.height() {
                     let mut color = image

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -6,6 +6,7 @@ use bevy_egui::{
     EguiContextSettings, EguiContexts, EguiPlugin, EguiPrimaryContextPass, EguiStartupSet,
     EguiTextureHandle,
 };
+use egui::{LayerId, Ui, UiBuilder};
 
 #[derive(Resource)]
 struct Images {
@@ -156,6 +157,14 @@ fn ui_example_system(
     }
 
     let ctx = contexts.ctx_mut()?;
+    let viewport_rect = ctx.viewport_rect();
+    let mut viewport_ui = Ui::new(
+        ctx.clone(),
+        "viewport".into(),
+        UiBuilder::new()
+            .layer_id(LayerId::background())
+            .max_rect(viewport_rect),
+    );
 
     let egui_texture_handle = ui_state
         .egui_texture_handle
@@ -173,9 +182,9 @@ fn ui_example_system(
     let mut remove = false;
     let mut invert = false;
 
-    egui::SidePanel::left("side_panel")
-        .default_width(200.0)
-        .show(ctx, |ui| {
+    egui::Panel::left("side_panel")
+        .default_size(200.0)
+        .show_inside(&mut viewport_ui, |ui| {
             ui.heading("Side Panel");
 
             ui.horizontal(|ui| {
@@ -217,7 +226,7 @@ fn ui_example_system(
             });
         });
 
-    egui::TopBottomPanel::top("top_panel").show(ctx, |ui| {
+    egui::Panel::top("top_panel").show_inside(&mut viewport_ui, |ui| {
         // The top panel is often a good place for a menu bar:
         egui::MenuBar::new().ui(ui, |ui| {
             egui::containers::menu::MenuButton::new("File").ui(ui, |ui| {
@@ -228,7 +237,7 @@ fn ui_example_system(
         });
     });
 
-    egui::CentralPanel::default().show(ctx, |ui| {
+    egui::CentralPanel::default().show_inside(&mut viewport_ui, |ui| {
         ui.heading("Egui Template");
         ui.hyperlink("https://github.com/emilk/egui_template");
         ui.add(egui::github_link_file_line!(

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -309,7 +309,7 @@ impl Default for Painting {
     fn default() -> Self {
         Self {
             lines: Default::default(),
-            stroke: egui::Stroke::new(1.0, egui::Color32::LIGHT_BLUE),
+            stroke: egui::Stroke::new(1.0_f32, egui::Color32::LIGHT_BLUE),
         }
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -19,7 +19,7 @@ use bevy_log::{self as log};
 use bevy_time::{Real, Time};
 use bevy_window::{CursorMoved, FileDragAndDrop, Ime, Window};
 use bevy_winit::WinitUserEvent;
-use egui::Modifiers;
+use egui::{Modifiers, TouchPhase};
 
 /// Cached pointer position, used to populate [`egui::Event::PointerButton`] messages.
 #[derive(Component, Default)]
@@ -552,6 +552,7 @@ pub fn write_mouse_wheel_messages_system(
                 unit,
                 delta,
                 modifiers,
+                phase: TouchPhase::Move,
             },
         });
     }
@@ -1329,14 +1330,15 @@ pub fn write_egui_wants_input_system(
     for mut ctx in egui_context_query.iter_mut() {
         let egui_ctx = ctx.get_mut();
         egui_wants_input.is_pointer_over_area =
-            egui_wants_input.is_pointer_over_area || egui_ctx.is_pointer_over_area();
+            egui_wants_input.is_pointer_over_area || egui_ctx.is_pointer_over_egui();
         egui_wants_input.wants_pointer_input =
-            egui_wants_input.wants_pointer_input || egui_ctx.wants_pointer_input();
+            egui_wants_input.wants_pointer_input || egui_ctx.egui_wants_pointer_input();
         egui_wants_input.is_using_pointer =
-            egui_wants_input.is_using_pointer || egui_ctx.is_using_pointer();
+            egui_wants_input.is_using_pointer || egui_ctx.egui_is_using_pointer();
         egui_wants_input.wants_keyboard_input =
-            egui_wants_input.wants_keyboard_input || egui_ctx.wants_keyboard_input();
-        egui_wants_input.is_popup_open = egui_wants_input.is_popup_open || egui_ctx.is_popup_open();
+            egui_wants_input.wants_keyboard_input || egui_ctx.egui_wants_keyboard_input();
+        egui_wants_input.is_popup_open =
+            egui_wants_input.is_popup_open || egui_ctx.any_popup_open();
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -1114,7 +1114,7 @@ pub fn write_egui_input_system(
 ) {
     for EguiInputEvent { context, event } in egui_input_reader.read() {
         #[cfg(feature = "log_input_messages")]
-        log::warn!("{context:?}: {message:?}");
+        log::warn!("{context:?}: {event:?}");
 
         let (_, mut egui_input) = match egui_contexts.get_mut(*context) {
             Ok(egui_input) => egui_input,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,13 +146,13 @@ pub mod prelude {
 
 pub use egui;
 
-use crate::input::*;
 #[cfg(target_arch = "wasm32")]
 use crate::text_agent::{
     SafariVirtualKeyboardTouchState, TextAgentChannel, VirtualTouchInfo, install_text_agent_system,
     is_mobile_safari, process_safari_virtual_keyboard_system,
     write_text_agent_channel_events_system,
 };
+use crate::{input::*, render::prepare_egui_pass};
 #[cfg(all(
     feature = "manage_clipboard",
     not(any(target_arch = "wasm32", target_os = "android"))
@@ -163,6 +163,7 @@ use bevy_app::prelude::*;
 use bevy_asset::{AssetEvent, AssetId, AssetMut, Assets, Handle, load_internal_asset};
 #[cfg(feature = "picking")]
 use bevy_camera::NormalizedRenderTarget;
+use bevy_core_pipeline::{Core2d, Core2dSystems, Core3d, Core3dSystems, upscaling::upscaling};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     lifecycle::HookContext,
@@ -1268,55 +1269,18 @@ impl Plugin for EguiPlugin {
                 return;
             };
 
-            let egui_graph_2d = render::get_egui_graph(render_app);
-            let egui_graph_3d = render::get_egui_graph(render_app);
-            let mut graph = render_app
-                .world_mut()
-                .resource_mut::<bevy_render::render_graph::RenderGraph>();
+            render_app.add_systems(Render, prepare_egui_pass.in_set(RenderSystems::Prepare));
 
-            if let Some(graph_2d) =
-                graph.get_sub_graph_mut(bevy_core_pipeline::core_2d::graph::Core2d)
-            {
-                graph_2d.add_sub_graph(render::graph::SubGraphEgui, egui_graph_2d);
-                graph_2d.add_node(
-                    render::graph::NodeEgui::EguiPass,
-                    render::RunEguiSubgraphOnEguiViewNode,
-                );
-                graph_2d.add_node_edge(
-                    bevy_core_pipeline::core_2d::graph::Node2d::EndMainPass,
-                    render::graph::NodeEgui::EguiPass,
-                );
-                graph_2d.add_node_edge(
-                    bevy_core_pipeline::core_2d::graph::Node2d::EndMainPassPostProcessing,
-                    render::graph::NodeEgui::EguiPass,
-                );
-                graph_2d.add_node_edge(
-                    render::graph::NodeEgui::EguiPass,
-                    bevy_core_pipeline::core_2d::graph::Node2d::Upscaling,
-                );
-            }
+            // TODO: Run systems either before or after `ui_pass` depending on `self.ui_render_order`
+            let egui_pass_2d = render::egui_pass
+                .after(Core2dSystems::MainPass)
+                .before(upscaling);
+            let egui_pass_3d = render::egui_pass
+                .after(Core3dSystems::MainPass)
+                .before(upscaling);
 
-            if let Some(graph_3d) =
-                graph.get_sub_graph_mut(bevy_core_pipeline::core_3d::graph::Core3d)
-            {
-                graph_3d.add_sub_graph(render::graph::SubGraphEgui, egui_graph_3d);
-                graph_3d.add_node(
-                    render::graph::NodeEgui::EguiPass,
-                    render::RunEguiSubgraphOnEguiViewNode,
-                );
-                graph_3d.add_node_edge(
-                    bevy_core_pipeline::core_3d::graph::Node3d::EndMainPass,
-                    render::graph::NodeEgui::EguiPass,
-                );
-                graph_3d.add_node_edge(
-                    bevy_core_pipeline::core_3d::graph::Node3d::EndMainPassPostProcessing,
-                    render::graph::NodeEgui::EguiPass,
-                );
-                graph_3d.add_node_edge(
-                    render::graph::NodeEgui::EguiPass,
-                    bevy_core_pipeline::core_3d::graph::Node3d::Upscaling,
-                );
-            }
+            render_app.add_systems(Core2d, egui_pass_2d);
+            render_app.add_systems(Core3d, egui_pass_3d);
         }
 
         #[cfg(feature = "accesskit")]
@@ -1328,9 +1292,6 @@ impl Plugin for EguiPlugin {
 
     #[cfg(feature = "render")]
     fn finish(&self, app: &mut App) {
-        #[cfg(feature = "bevy_ui")]
-        let bevy_ui_is_enabled = app.is_plugin_added::<bevy_ui_render::UiRenderPlugin>();
-
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
                 .insert_resource(render::EguiRenderSettings {
@@ -1363,60 +1324,6 @@ impl Plugin for EguiPlugin {
                     Render,
                     render::systems::queue_pipelines_system.in_set(RenderSystems::Queue),
                 );
-
-            // Configure a fixed rendering order between Bevy UI and egui.
-            // Otherwise, this order is effectively decided at random on every game startup.
-            #[cfg(feature = "bevy_ui")]
-            if bevy_ui_is_enabled {
-                use bevy_render::render_graph::RenderLabel;
-                let mut graph = render_app
-                    .world_mut()
-                    .resource_mut::<bevy_render::render_graph::RenderGraph>();
-                let (below, above) = match self.ui_render_order {
-                    UiRenderOrder::EguiAboveBevyUi => (
-                        bevy_ui_render::graph::NodeUi::UiPass.intern(),
-                        render::graph::NodeEgui::EguiPass.intern(),
-                    ),
-                    UiRenderOrder::BevyUiAboveEgui => (
-                        render::graph::NodeEgui::EguiPass.intern(),
-                        bevy_ui_render::graph::NodeUi::UiPass.intern(),
-                    ),
-                };
-                if let Some(graph_2d) =
-                    graph.get_sub_graph_mut(bevy_core_pipeline::core_2d::graph::Core2d)
-                {
-                    // Only apply if the bevy_ui plugin is actually enabled.
-                    // In theory we could use RenderGraph::try_add_node_edge instead and ignore the result,
-                    // but that still seems to end up writing the corrupt edge into the graph,
-                    // causing the game to panic down the line.
-                    match graph_2d.get_node_state(bevy_ui_render::graph::NodeUi::UiPass) {
-                        Ok(_) => {
-                            graph_2d.add_node_edge(below, above);
-                        }
-                        Err(err) => log::warn!(
-                            error = &err as &dyn std::error::Error,
-                            "bevy_ui::UiPlugin is enabled but could not be found in 2D render graph, rendering order will be inconsistent",
-                        ),
-                    }
-                }
-                if let Some(graph_3d) =
-                    graph.get_sub_graph_mut(bevy_core_pipeline::core_3d::graph::Core3d)
-                {
-                    match graph_3d.get_node_state(bevy_ui_render::graph::NodeUi::UiPass) {
-                        Ok(_) => {
-                            graph_3d.add_node_edge(below, above);
-                        }
-                        Err(err) => log::warn!(
-                            error = &err as &dyn std::error::Error,
-                            "bevy_ui::UiPlugin is enabled but could not be found in 3D render graph, rendering order will be inconsistent",
-                        ),
-                    }
-                }
-            } else {
-                log::debug!(
-                    "bevy_ui feature is enabled, but bevy_ui::UiPlugin is disabled, not applying configured rendering order"
-                )
-            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1858,7 +1858,7 @@ pub fn run_egui_context_pass_loop_system(world: &mut World) {
             );
         }
 
-        let output = ctx.run_ui(input.take(), |_| {
+        let output = ctx.run(input.take(), |_| {
             let _ = world.try_run_schedule(*multipass_schedule);
         });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,13 +146,13 @@ pub mod prelude {
 
 pub use egui;
 
+use crate::input::*;
 #[cfg(target_arch = "wasm32")]
 use crate::text_agent::{
     SafariVirtualKeyboardTouchState, TextAgentChannel, VirtualTouchInfo, install_text_agent_system,
     is_mobile_safari, process_safari_virtual_keyboard_system,
     write_text_agent_channel_events_system,
 };
-use crate::{input::*, render::prepare_egui_pass};
 #[cfg(all(
     feature = "manage_clipboard",
     not(any(target_arch = "wasm32", target_os = "android"))
@@ -163,7 +163,6 @@ use bevy_app::prelude::*;
 use bevy_asset::{AssetEvent, AssetId, AssetMut, Assets, Handle, load_internal_asset};
 #[cfg(feature = "picking")]
 use bevy_camera::NormalizedRenderTarget;
-use bevy_core_pipeline::{Core2d, Core2dSystems, Core3d, Core3dSystems, upscaling::upscaling};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     lifecycle::HookContext,
@@ -1270,11 +1269,11 @@ impl Plugin for EguiPlugin {
             };
 
             let egui_pass_2d = render::egui_pass
-                .after(Core2dSystems::MainPass)
-                .before(upscaling);
+                .after(bevy_core_pipeline::Core2dSystems::MainPass)
+                .before(bevy_core_pipeline::upscaling::upscaling);
             let egui_pass_3d = render::egui_pass
-                .after(Core3dSystems::MainPass)
-                .before(upscaling);
+                .after(bevy_core_pipeline::Core3dSystems::MainPass)
+                .before(bevy_core_pipeline::upscaling::upscaling);
 
             #[cfg(feature = "bevy_ui")]
             let (egui_pass_2d, egui_pass_3d) = {
@@ -1289,8 +1288,14 @@ impl Plugin for EguiPlugin {
                 }
             };
 
-            render_app.add_systems(Core2d, (prepare_egui_pass, egui_pass_2d).chain());
-            render_app.add_systems(Core3d, (prepare_egui_pass, egui_pass_3d).chain());
+            render_app.add_systems(
+                bevy_core_pipeline::Core2d,
+                (render::prepare_egui_pass, egui_pass_2d).chain(),
+            );
+            render_app.add_systems(
+                bevy_core_pipeline::Core3d,
+                (render::prepare_egui_pass, egui_pass_3d).chain(),
+            );
         }
 
         #[cfg(feature = "accesskit")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -434,7 +434,7 @@ pub struct EnableMultipassForPrimaryContext;
 /// A component for storing Egui context settings.
 #[derive(Clone, Debug, Component, Reflect)]
 pub struct EguiContextSettings {
-    /// If set to `true`, a user is expected to call [`egui::Context::run`] or [`egui::Context::begin_pass`] and [`egui::Context::end_pass`] manually.
+    /// If set to `true`, a user is expected to call [`egui::Context::run_ui`] or [`egui::Context::begin_pass`] and [`egui::Context::end_pass`] manually.
     pub run_manually: bool,
     /// Global scale factor for Egui widgets (`1.0` by default).
     ///
@@ -1400,11 +1400,10 @@ pub fn setup_accesskit_system(
             if let Some(window_entity) = window_to_egui_context_map
                 .context_to_window
                 .get(&new_context_entity)
+                && adapters.contains_key(window_entity)
             {
-                if adapters.contains_key(window_entity) {
-                    context.ctx.enable_accesskit();
-                    **manage_accessibility_updates = false;
-                }
+                context.ctx.enable_accesskit();
+                **manage_accessibility_updates = false;
             }
         }
     });
@@ -1557,7 +1556,7 @@ pub fn capture_pointer_input_system(
                     continue;
                 }
 
-                if settings.capture_pointer_input && ctx.get_mut().wants_pointer_input() {
+                if settings.capture_pointer_input && ctx.get_mut().egui_wants_pointer_input() {
                     let entry = (entity, HitData::new(entity, 0.0, None, None));
                     output.write(PointerHits::new(
                         *pointer,
@@ -1859,7 +1858,7 @@ pub fn run_egui_context_pass_loop_system(world: &mut World) {
             );
         }
 
-        let output = ctx.run(input.take(), |_| {
+        let output = ctx.run_ui(input.take(), |_| {
             let _ = world.try_run_schedule(*multipass_schedule);
         });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@ use crate::text_agent::{
 use arboard::Clipboard;
 use bevy_app::prelude::*;
 #[cfg(feature = "render")]
-use bevy_asset::{AssetEvent, AssetId, Assets, Handle, load_internal_asset};
+use bevy_asset::{AssetEvent, AssetId, AssetMut, Assets, Handle, load_internal_asset};
 #[cfg(feature = "picking")]
 use bevy_camera::NormalizedRenderTarget;
 use bevy_derive::{Deref, DerefMut};
@@ -1702,7 +1702,7 @@ pub fn update_egui_textures_system(
     }
 
     fn update_image_rect(
-        dest: &mut Image,
+        mut dest: AssetMut<Image>,
         [x, y]: [usize; 2],
         src: &egui::ColorImage,
     ) -> Result<(), TextureAccessError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1269,16 +1269,29 @@ impl Plugin for EguiPlugin {
                 return;
             };
 
-            render_app.add_systems(Render, prepare_egui_pass.in_set(RenderSystems::Prepare));
-
-            // TODO: Run systems either before or after `ui_pass` depending on `self.ui_render_order`
-            let egui_pass_2d = render::egui_pass
+            let mut egui_pass_2d = render::egui_pass
                 .after(Core2dSystems::MainPass)
                 .before(upscaling);
-            let egui_pass_3d = render::egui_pass
+            let mut egui_pass_3d = render::egui_pass
                 .after(Core3dSystems::MainPass)
                 .before(upscaling);
 
+            #[cfg(feature = "bevy_ui")]
+            {
+                use bevy_ui_render::ui_pass;
+                match self.ui_render_order {
+                    UiRenderOrder::EguiAboveBevyUi => {
+                        egui_pass_2d = egui_pass_2d.after(ui_pass);
+                        egui_pass_3d = egui_pass_3d.after(ui_pass);
+                    }
+                    UiRenderOrder::BevyUiAboveEgui => {
+                        egui_pass_2d = egui_pass_2d.before(ui_pass);
+                        egui_pass_3d = egui_pass_3d.before(ui_pass);
+                    }
+                }
+            }
+
+            render_app.add_systems(Render, prepare_egui_pass.in_set(RenderSystems::Prepare));
             render_app.add_systems(Core2d, egui_pass_2d);
             render_app.add_systems(Core3d, egui_pass_3d);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1269,27 +1269,25 @@ impl Plugin for EguiPlugin {
                 return;
             };
 
-            let mut egui_pass_2d = render::egui_pass
+            let egui_pass_2d = render::egui_pass
                 .after(Core2dSystems::MainPass)
                 .before(upscaling);
-            let mut egui_pass_3d = render::egui_pass
+            let egui_pass_3d = render::egui_pass
                 .after(Core3dSystems::MainPass)
                 .before(upscaling);
 
             #[cfg(feature = "bevy_ui")]
-            {
+            let (egui_pass_2d, egui_pass_3d) = {
                 use bevy_ui_render::ui_pass;
                 match self.ui_render_order {
                     UiRenderOrder::EguiAboveBevyUi => {
-                        egui_pass_2d = egui_pass_2d.after(ui_pass);
-                        egui_pass_3d = egui_pass_3d.after(ui_pass);
+                        (egui_pass_2d.after(ui_pass), egui_pass_3d.after(ui_pass))
                     }
                     UiRenderOrder::BevyUiAboveEgui => {
-                        egui_pass_2d = egui_pass_2d.before(ui_pass);
-                        egui_pass_3d = egui_pass_3d.before(ui_pass);
+                        (egui_pass_2d.before(ui_pass), egui_pass_3d.before(ui_pass))
                     }
                 }
-            }
+            };
 
             render_app.add_systems(Core2d, (prepare_egui_pass, egui_pass_2d).chain());
             render_app.add_systems(Core3d, (prepare_egui_pass, egui_pass_3d).chain());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -607,7 +607,7 @@ pub struct EguiRenderOutput {
     /// Pairs of rectangles and paint commands.
     ///
     /// The field gets populated during the [`EguiPostUpdateSet::ProcessOutput`] system (belonging to bevy's [`PostUpdate`])
-    /// and processed during [`render::EguiPassNode`]'s `update`.
+    /// and processed during [`render::systems::prepare_egui_render_target_data_system`].
     pub paint_jobs: Vec<egui::ClippedPrimitive>,
     /// The change in egui textures since last frame.
     pub textures_delta: egui::TexturesDelta,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1291,9 +1291,8 @@ impl Plugin for EguiPlugin {
                 }
             }
 
-            render_app.add_systems(Render, prepare_egui_pass.in_set(RenderSystems::Prepare));
-            render_app.add_systems(Core2d, egui_pass_2d);
-            render_app.add_systems(Core3d, egui_pass_3d);
+            render_app.add_systems(Core2d, (prepare_egui_pass, egui_pass_2d).chain());
+            render_app.add_systems(Core3d, (prepare_egui_pass, egui_pass_3d).chain());
         }
 
         #[cfg(feature = "accesskit")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1858,7 +1858,7 @@ pub fn run_egui_context_pass_loop_system(world: &mut World) {
             );
         }
 
-        let output = ctx.run(input.take(), |_| {
+        let output = ctx.run_ui(input.take(), |_| {
             let _ = world.try_run_schedule(*multipass_schedule);
         });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -996,7 +996,7 @@ impl Plugin for EguiPlugin {
         }
 
         #[cfg(target_arch = "wasm32")]
-        app.init_non_send_resource::<SubscribedEvents>();
+        app.init_non_send::<SubscribedEvents>();
 
         #[cfg(all(feature = "manage_clipboard", not(target_os = "android")))]
         app.init_resource::<EguiClipboard>();

--- a/src/picking.rs
+++ b/src/picking.rs
@@ -2,7 +2,6 @@ use crate::{
     EguiContext, helpers,
     input::{EguiContextPointerPosition, HoveredNonWindowEguiContext},
 };
-use bevy_asset::Assets;
 use bevy_camera::{Camera, NormalizedRenderTarget, RenderTarget};
 use bevy_ecs::{
     change_detection::Res,
@@ -10,17 +9,15 @@ use bevy_ecs::{
     entity::Entity,
     error::Result,
     observer::On,
-    prelude::{AnyOf, Commands, Query, With},
+    prelude::{Commands, Query, With},
 };
-use bevy_math::{Ray3d, Vec2};
-use bevy_mesh::{Indices, Mesh, Mesh2d, Mesh3d, VertexAttributeValues};
+use bevy_math::Ray3d;
 use bevy_picking::{
     Pickable,
     events::{Move, Out, Over, Pointer},
     mesh_picking::ray_cast::RayMeshHit,
     prelude::{MeshRayCast, MeshRayCastSettings, RayCastVisibility},
 };
-use bevy_render::render_resource::PrimitiveTopology;
 use bevy_transform::components::GlobalTransform;
 use bevy_window::PrimaryWindow;
 
@@ -36,9 +33,8 @@ pub fn handle_move_system(
     mut mesh_ray_cast: MeshRayCast,
     mut egui_pointers: Query<&mut EguiContextPointerPosition>,
     egui_contexts: Query<(&Camera, &GlobalTransform, &RenderTarget), With<EguiContext>>,
-    pickable_egui_context_query: Query<(&PickableEguiContext, AnyOf<(&Mesh2d, &Mesh3d)>)>,
+    pickable_egui_context_query: Query<&PickableEguiContext>,
     primary_window_query: Query<Entity, With<PrimaryWindow>>,
-    meshes: Res<Assets<Mesh>>,
 ) -> Result {
     let NormalizedRenderTarget::Window(_) = event.pointer_location.target else {
         return Ok(());
@@ -66,63 +62,14 @@ pub fn handle_move_system(
     ) else {
         return Ok(());
     };
-    let &[
-        (
-            hit_entity,
-            RayMeshHit {
-                triangle_index: Some(triangle_index),
-                barycentric_coords,
-                ..
-            },
-        ),
-    ] = mesh_ray_cast.cast_ray(ray, &settings)
+    let &[(hit_entity, RayMeshHit { uv: Some(uv), .. })] = mesh_ray_cast.cast_ray(ray, &settings)
     else {
         return Ok(());
     };
 
     // At this point, we expect that the context exists, since we checked that with the ray cast filter.
-    let (&PickableEguiContext(context), mesh) = pickable_egui_context_query.get(hit_entity)?;
+    let &PickableEguiContext(context) = pickable_egui_context_query.get(hit_entity)?;
     let (egui_mesh_camera, _, _) = egui_contexts.get(context)?;
-
-    // Read triangle indices and the respective UVs of the mesh.
-    let handle = match mesh {
-        (Some(handle), None) => handle.0.clone(),
-        (None, Some(handle)) => handle.0.clone(),
-        _ => unreachable!(),
-    };
-    let Some(mesh) = meshes.get(handle.id()) else {
-        return Ok(());
-    };
-    // The bevy_picking ray cast backend expects only the TriangleList primitive topology (at least that was the case at the moment of writing).
-    if mesh.primitive_topology() != PrimitiveTopology::TriangleList {
-        panic!(
-            "Unexpected primitive topology for a picked mesh ({:?}): {:?}",
-            event.observer(),
-            mesh.primitive_topology()
-        );
-    }
-    let Some(indices) = mesh.indices() else {
-        return Ok(());
-    };
-    let Some(uv_values) =
-        mesh.attribute(Mesh::ATTRIBUTE_UV_0)
-            .and_then(|values| match (values, indices) {
-                (VertexAttributeValues::Float32x2(uvs), Indices::U16(indices)) => {
-                    uv_values_for_triangle(indices, triangle_index, uvs)
-                }
-                (VertexAttributeValues::Float32x2(uvs), Indices::U32(indices)) => {
-                    uv_values_for_triangle(indices, triangle_index, uvs)
-                }
-                _ => None,
-            })
-    else {
-        return Ok(());
-    };
-
-    // Interpolate UVs based on the barycentric coordinates.
-    let uv = Vec2::from_array(uv_values[0]) * barycentric_coords.x
-        + Vec2::from_array(uv_values[1]) * barycentric_coords.y
-        + Vec2::from_array(uv_values[2]) * barycentric_coords.z;
 
     // The only thing we need to do here from the Egui context perspective is to update the `EguiContextPointerPosition` component.
     // Other input systems will take care of the rest.
@@ -140,7 +87,7 @@ pub fn handle_over_system(
     pickable_egui_context_query: Query<&PickableEguiContext>,
     mut commands: Commands,
 ) {
-    if let Ok(&PickableEguiContext(context)) = pickable_egui_context_query.get(event.observer()) {
+    if let Ok(&PickableEguiContext(context)) = pickable_egui_context_query.get(event.entity) {
         commands.insert_resource(HoveredNonWindowEguiContext(context));
     }
 }
@@ -152,29 +99,13 @@ pub fn handle_out_system(
     mut commands: Commands,
     hovered_non_window_egui_context: Option<Res<HoveredNonWindowEguiContext>>,
 ) {
-    if let Ok(&PickableEguiContext(context)) = pickable_egui_context_query.get(event.observer())
+    if let Ok(&PickableEguiContext(context)) = pickable_egui_context_query.get(event.entity)
         && hovered_non_window_egui_context
             .as_deref()
             .is_some_and(|&HoveredNonWindowEguiContext(hovered_context)| hovered_context == context)
     {
         commands.remove_resource::<HoveredNonWindowEguiContext>();
     }
-}
-
-fn uv_values_for_triangle<I: TryInto<usize> + Clone + Copy>(
-    indices: &[I],
-    triangle_index: usize,
-    values: &[[f32; 2]],
-) -> Option<[[f32; 2]; 3]> {
-    if !indices.len().is_multiple_of(3) || triangle_index >= indices.len() {
-        return None;
-    }
-
-    let i0 = indices[triangle_index * 3].try_into().ok()?;
-    let i1 = indices[triangle_index * 3 + 1].try_into().ok()?;
-    let i2 = indices[triangle_index * 3 + 2].try_into().ok()?;
-
-    Some([*values.get(i1)?, *values.get(i2)?, *values.get(i0)?])
 }
 
 fn make_ray(

--- a/src/picking.rs
+++ b/src/picking.rs
@@ -20,9 +20,9 @@ use bevy_picking::{
     mesh_picking::ray_cast::RayMeshHit,
     prelude::{MeshRayCast, MeshRayCastSettings, RayCastVisibility},
 };
+use bevy_render::render_resource::PrimitiveTopology;
 use bevy_transform::components::GlobalTransform;
 use bevy_window::PrimaryWindow;
-use wgpu_types::PrimitiveTopology;
 
 /// This component marks an Entity that displays Egui as an image for [`bevy_picking`] integration
 /// (currently, only [`bevy_mesh::Mesh2d`] or [`bevy_mesh::Mesh3d`] are supported for picking).

--- a/src/render/egui.wgsl
+++ b/src/render/egui.wgsl
@@ -21,12 +21,12 @@ struct VertexOutput {
 @group(1) @binding(0) var image_texture: binding_array<texture_2d<f32>>;
 @group(1) @binding(1) var image_sampler: binding_array<sampler>;
 
-// Fix for DX12 backend in wgpu which appears to only support struct push constants
-// wgpu::backend::wgpu_core: Shader translation error for stage ShaderStages(FRAGMENT): HLSL: Unimplemented("push-constant 'offset' has non-struct type; tracked by: https://github.com/gfx-rs/wgpu/issues/5683")
+// Fix for DX12 backend in wgpu which appears to only support struct immediates
+// wgpu::backend::wgpu_core: Shader translation error for stage ShaderStages(FRAGMENT): HLSL: Unimplemented("immediate 'offset' has non-struct type; tracked by: https://github.com/gfx-rs/wgpu/issues/5683")
 struct BindlessOffset {
     offset: u32,
 };
-var<push_constant> offset: BindlessOffset;
+var<immediate> offset: BindlessOffset;
 
 #else //BINDLESS
 @group(1) @binding(0) var image_texture: texture_2d<f32>;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -141,6 +141,7 @@ pub fn extract_egui_camera_view_system(
                         )),
                         color_grading: Default::default(),
                         invert_culling: false,
+                        compositing_space: None,
                     },
                     // Link to the main camera view.
                     EguiViewTarget(render_entity),

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -62,7 +62,7 @@ use bevy_render::{render_resource::BindGroupLayoutDescriptor, renderer::RenderAd
 use systems::{EguiTextureId, EguiTransform};
 use wgpu_types::{
     Backend, BlendState, ColorTargetState, ColorWrites, Extent3d, Features, Limits,
-    MultisampleState, PrimitiveState, PushConstantRange, SamplerBindingType, ShaderStages,
+    MultisampleState, PrimitiveState, SamplerBindingType, ShaderStages,
     TextureDimension, TextureFormat, TextureSampleType, VertexFormat, VertexStepMode,
 };
 
@@ -303,8 +303,8 @@ impl EguiPipeline {
             } else if !device_features.contains(Features::TEXTURE_BINDING_ARRAY) {
                 warn!("Feature TEXTURE_BINDING_ARRAY is not supported on this device.");
                 None
-            } else if !device_features.contains(Features::PUSH_CONSTANTS) {
-                warn!("Feature PUSH_CONSTANTS is not supported on this device.");
+            } else if !device_features.contains(Features::IMMEDIATES) {
+                warn!("Feature IMMEDIATES is not supported on this device.");
                 None
             } else {
                 match NonZeroU32::new(min(
@@ -355,14 +355,11 @@ impl SpecializedRenderPipeline for EguiPipeline {
 
     fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
         let mut shader_defs = Vec::new();
-        let mut push_constant_ranges = Vec::new();
+        let mut immediate_size = 0;
 
         if let Some(bindless) = self.bindless {
             shader_defs.push(ShaderDefVal::UInt("BINDLESS".into(), u32::from(bindless)));
-            push_constant_ranges.push(PushConstantRange {
-                stages: ShaderStages::FRAGMENT,
-                range: 0..4,
-            });
+            immediate_size = 4;
         }
 
         RenderPipelineDescriptor {
@@ -401,7 +398,7 @@ impl SpecializedRenderPipeline for EguiPipeline {
             primitive: PrimitiveState::default(),
             depth_stencil: None,
             multisample: MultisampleState::default(),
-            push_constant_ranges,
+            immediate_size,
             zero_initialize_workgroup_memory: false,
         }
     }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -15,9 +15,7 @@ use bevy_ecs::{
     system::{Commands, Local, ResMut},
     world::{FromWorld, World},
 };
-use bevy_image::{
-    BevyDefault, Image, ImageAddressMode, ImageFilterMode, ImageSampler, ImageSamplerDescriptor,
-};
+use bevy_image::{Image, ImageAddressMode, ImageFilterMode, ImageSampler, ImageSamplerDescriptor};
 use bevy_math::{Mat4, UVec4};
 use bevy_mesh::VertexBufferLayout;
 use bevy_platform::collections::HashSet;
@@ -31,7 +29,7 @@ use bevy_render::{
     },
     renderer::{RenderContext, RenderDevice},
     sync_world::{RenderEntity, TemporaryRenderEntity},
-    view::{ExtractedView, RetainedViewEntity, ViewTarget},
+    view::{ExtractedView, RetainedViewEntity},
 };
 use bevy_shader::{Shader, ShaderDefVal};
 use egui::{TextureFilter, TextureOptions};
@@ -134,14 +132,17 @@ pub fn extract_egui_camera_view_system(
                             UI_CAMERA_FAR + UI_CAMERA_TRANSFORM_OFFSET,
                         ),
                         clip_from_world: None,
-                        hdr,
+                        target_format: if hdr {
+                            TextureFormat::Rgba16Float
+                        } else {
+                            TextureFormat::Rgba8UnormSrgb
+                        },
                         viewport: UVec4::from((
                             physical_viewport_rect.min,
                             physical_viewport_rect.size(),
                         )),
                         color_grading: Default::default(),
                         invert_culling: false,
-                        compositing_space: None,
                     },
                     // Link to the main camera view.
                     EguiViewTarget(render_entity),
@@ -297,8 +298,9 @@ impl EguiPipeline {
 /// Key for specialized pipeline.
 #[derive(PartialEq, Eq, Hash, Clone, Copy)]
 pub struct EguiPipelineKey {
-    /// Equals `true` for cameras that have the [`Hdr`] component.
-    pub hdr: bool,
+    /// It uses `TextureFormat::Rgba16Float` for cameras with HDR enabled,
+    /// otherwise it defaults to `TextureFormat::Rgba8UnormSrgb`.
+    pub target_format: TextureFormat,
 }
 
 impl SpecializedRenderPipeline for EguiPipeline {
@@ -337,11 +339,7 @@ impl SpecializedRenderPipeline for EguiPipeline {
                 shader_defs,
                 entry_point: Some("fs_main".into()),
                 targets: vec![Some(ColorTargetState {
-                    format: if key.hdr {
-                        ViewTarget::TEXTURE_FORMAT_HDR
-                    } else {
-                        TextureFormat::bevy_default()
-                    },
+                    format: key.target_format,
                     blend: Some(BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask: ColorWrites::ALL,
                 })],

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -431,7 +431,7 @@ pub(crate) fn texture_options_as_sampler_descriptor(
     }
 }
 
-/// Callback to execute custom 'wgpu' rendering inside [`EguiPassNode`] render graph node.
+/// Callback to execute custom 'wgpu' rendering inside [`egui_pass`].
 ///
 /// Rendering can be implemented using for example:
 /// * native wgpu rendering libraries,
@@ -456,9 +456,9 @@ impl EguiBevyPaintCallback {
     }
 }
 
-/// Callback that executes custom rendering logic
+/// Callback that executes custom rendering logic.
 pub trait EguiBevyPaintCallbackImpl: Send + Sync {
-    /// Paint callback will be rendered in near future, all data must be finalized for render step
+    /// Paint callback will be rendered in near future, all data must be finalized for render step.
     fn update(
         &self,
         info: egui::PaintCallbackInfo,
@@ -467,11 +467,10 @@ pub trait EguiBevyPaintCallbackImpl: Send + Sync {
         world: &mut World,
     );
 
-    /// Paint callback call before render step
-    ///
+    /// Paint callback call before render step.
     ///
     /// Can be used to implement custom render passes
-    /// or to submit command buffers for execution before egui render pass
+    /// or to submit command buffers for execution before egui render pass.
     fn prepare_render<'w, 's>(
         &self,
         info: egui::PaintCallbackInfo,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 use bevy_app::SubApp;
 use bevy_asset::{Handle, RenderAssetUsages, uuid_handle};
-use bevy_camera::Camera;
+use bevy_camera::{Camera, Hdr};
 use bevy_ecs::{
     component::Component,
     entity::Entity,
@@ -52,7 +52,7 @@ use bevy_render::{
     },
     renderer::{RenderContext, RenderDevice},
     sync_world::{RenderEntity, TemporaryRenderEntity},
-    view::{ExtractedView, Hdr, RetainedViewEntity, ViewTarget},
+    view::{ExtractedView, RetainedViewEntity, ViewTarget},
 };
 use bevy_shader::{Shader, ShaderDefVal};
 use egui::{TextureFilter, TextureOptions};

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -4,27 +4,7 @@ use std::{
     num::{NonZero, NonZeroU32},
 };
 
-/// Defines Egui node graph.
-pub mod graph {
-    use bevy_render::render_graph::{RenderLabel, RenderSubGraph};
-
-    /// Egui subgraph (is run by [`super::RunEguiSubgraphOnEguiViewNode`]).
-    #[derive(Debug, Hash, PartialEq, Eq, Clone, RenderSubGraph)]
-    pub struct SubGraphEgui;
-
-    /// Egui node defining the Egui rendering pass.
-    #[derive(Debug, Hash, PartialEq, Eq, Clone, RenderLabel)]
-    pub enum NodeEgui {
-        /// Egui rendering pass.
-        EguiPass,
-    }
-}
-
-use crate::{
-    EguiContextSettings, EguiRenderOutput, RenderComputedScaleFactor,
-    render::graph::{NodeEgui, SubGraphEgui},
-};
-use bevy_app::SubApp;
+use crate::{EguiContextSettings, EguiRenderOutput, RenderComputedScaleFactor};
 use bevy_asset::{Handle, RenderAssetUsages, uuid_handle};
 use bevy_camera::{Camera, Hdr};
 use bevy_ecs::{
@@ -43,7 +23,6 @@ use bevy_mesh::VertexBufferLayout;
 use bevy_platform::collections::HashSet;
 use bevy_render::{
     MainWorld,
-    render_graph::{Node, NodeRunError, RenderGraph, RenderGraphContext},
     render_phase::TrackedRenderPass,
     render_resource::{
         BindGroupLayoutEntries, FragmentState, RenderPipelineDescriptor, SpecializedRenderPipeline,
@@ -62,8 +41,8 @@ use bevy_render::{render_resource::BindGroupLayoutDescriptor, renderer::RenderAd
 use systems::{EguiTextureId, EguiTransform};
 use wgpu_types::{
     Backend, BlendState, ColorTargetState, ColorWrites, Extent3d, Features, Limits,
-    MultisampleState, PrimitiveState, SamplerBindingType, ShaderStages,
-    TextureDimension, TextureFormat, TextureSampleType, VertexFormat, VertexStepMode,
+    MultisampleState, PrimitiveState, SamplerBindingType, ShaderStages, TextureDimension,
+    TextureFormat, TextureSampleType, VertexFormat, VertexStepMode,
 };
 
 mod render_pass;
@@ -90,38 +69,6 @@ pub struct EguiCameraView(pub Entity);
 /// This is the inverse of [`EguiCameraView`].
 #[derive(Component, Debug)]
 pub struct EguiViewTarget(pub Entity);
-
-/// Adds and returns an Egui subgraph.
-pub fn get_egui_graph(render_app: &mut SubApp) -> RenderGraph {
-    let pass_node = EguiPassNode::new(render_app.world_mut());
-    let mut graph = RenderGraph::default();
-    graph.add_node(NodeEgui::EguiPass, pass_node);
-    graph
-}
-
-/// A [`Node`] that executes the Egui rendering subgraph on the Egui view.
-pub struct RunEguiSubgraphOnEguiViewNode;
-
-impl Node for RunEguiSubgraphOnEguiViewNode {
-    fn run<'w>(
-        &self,
-        graph: &mut RenderGraphContext,
-        _: &mut RenderContext<'w>,
-        world: &'w World,
-    ) -> Result<(), NodeRunError> {
-        // Fetch the UI view.
-        let Some(mut render_views) = world.try_query::<&EguiCameraView>() else {
-            return Ok(());
-        };
-        let Ok(default_camera_view) = render_views.get(world, graph.view_entity()) else {
-            return Ok(());
-        };
-
-        // Run the subgraph on the Egui view.
-        graph.run_sub_graph(SubGraphEgui, vec![], Some(default_camera_view.0), None)?;
-        Ok(())
-    }
-}
 
 /// Extracts all Egui contexts associated with a camera into the render world.
 pub fn extract_egui_camera_view_system(
@@ -523,10 +470,10 @@ pub trait EguiBevyPaintCallbackImpl: Send + Sync {
     ///
     /// Can be used to implement custom render passes
     /// or to submit command buffers for execution before egui render pass
-    fn prepare_render<'w>(
+    fn prepare_render<'w, 's>(
         &self,
         info: egui::PaintCallbackInfo,
-        render_context: &mut RenderContext<'w>,
+        render_context: &mut RenderContext<'w, 's>,
         render_entity: RenderEntity,
         pipeline_key: EguiPipelineKey,
         world: &'w World,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -37,13 +37,16 @@ use bevy_shader::{Shader, ShaderDefVal};
 use egui::{TextureFilter, TextureOptions};
 
 use bevy_log::{error, info, warn};
-use bevy_render::{render_resource::BindGroupLayoutDescriptor, renderer::RenderAdapterInfo};
-use systems::{EguiTextureId, EguiTransform};
-use wgpu_types::{
-    Backend, BlendState, ColorTargetState, ColorWrites, Extent3d, Features, Limits,
-    MultisampleState, PrimitiveState, SamplerBindingType, ShaderStages, TextureDimension,
-    TextureFormat, TextureSampleType, VertexFormat, VertexStepMode,
+use bevy_render::{
+    render_resource::{
+        BindGroupLayoutDescriptor, BlendState, ColorTargetState, ColorWrites, Extent3d,
+        MultisampleState, PrimitiveState, SamplerBindingType, ShaderStages, TextureDimension,
+        TextureFormat, TextureSampleType, VertexFormat, VertexStepMode,
+    },
+    renderer::RenderAdapterInfo,
 };
+use systems::{EguiTextureId, EguiTransform};
+use wgpu_types::{Backend, Features, Limits};
 
 mod render_pass;
 /// Plugin systems for the render app.

--- a/src/render/render_pass.rs
+++ b/src/render/render_pass.rs
@@ -1,5 +1,5 @@
 use crate::render::{
-    DrawPrimitive,
+    DrawPrimitive, EguiCameraView, EguiViewTarget,
     systems::{EguiPipelines, EguiRenderData, EguiTextureBindGroups, EguiTransforms},
 };
 use bevy_camera::Viewport;
@@ -15,7 +15,6 @@ use bevy_render::{
     sync_world::RenderEntity,
     view::{ExtractedView, ViewTarget},
 };
-use bevy_ui_render::{UiCameraView, UiViewTarget};
 use wgpu_types::IndexFormat;
 
 pub fn prepare_egui_pass(world: &mut World) {
@@ -44,19 +43,19 @@ pub fn prepare_egui_pass(world: &mut World) {
 
 pub fn egui_pass(
     world: &World,
-    view: ViewQuery<&UiCameraView>,
-    ui_view_query: Query<(&ExtractedView, &UiViewTarget)>,
+    view: ViewQuery<&EguiCameraView>,
+    ui_view_query: Query<(&ExtractedView, &EguiViewTarget)>,
     ui_view_target_query: Query<(&ViewTarget, &ExtractedCamera)>,
     mut ctx: RenderContext,
 ) {
     let ui_camera_view = view.into_inner();
     let ui_view_entity = ui_camera_view.0;
 
-    let Ok((extracted_view, ui_view_target)) = ui_view_query.get(ui_view_entity) else {
+    let Ok((extracted_view, egui_view_target)) = ui_view_query.get(ui_view_entity) else {
         return;
     };
 
-    let Ok((target, camera)) = ui_view_target_query.get(ui_view_target.0) else {
+    let Ok((target, camera)) = ui_view_target_query.get(egui_view_target.0) else {
         return;
     };
 

--- a/src/render/render_pass.rs
+++ b/src/render/render_pass.rs
@@ -214,11 +214,10 @@ impl Node for EguiPassNode {
                     {
                         last_bindless_offset = Some(bindless_offset);
 
-                        // Use push constant to cheaply provide which texture to use inside
+                        // Use immediates to cheaply provide which texture to use inside
                         // binding array. This is used to avoid costly set_bind_group operations
                         // when frequent switching between textures is being done
-                        render_pass.set_push_constants(
-                            ShaderStages::FRAGMENT,
+                        render_pass.set_immediates(
                             0,
                             bytemuck::bytes_of(bindless_offset),
                         );

--- a/src/render/render_pass.rs
+++ b/src/render/render_pass.rs
@@ -1,268 +1,241 @@
 use crate::render::{
-    DrawPrimitive, EguiViewTarget,
+    DrawPrimitive,
     systems::{EguiPipelines, EguiRenderData, EguiTextureBindGroups, EguiTransforms},
 };
 use bevy_camera::Viewport;
 use bevy_ecs::{
-    query::QueryState,
+    prelude::Query,
     world::{Mut, World},
 };
 use bevy_math::{URect, UVec2};
 use bevy_render::{
     camera::ExtractedCamera,
-    render_graph::{Node, NodeRunError, RenderGraphContext},
     render_resource::{PipelineCache, RenderPassDescriptor},
-    renderer::RenderContext,
+    renderer::{RenderContext, ViewQuery},
     sync_world::RenderEntity,
     view::{ExtractedView, ViewTarget},
 };
-use wgpu_types::{IndexFormat, ShaderStages};
+use bevy_ui_render::{UiCameraView, UiViewTarget};
+use wgpu_types::IndexFormat;
 
-/// Egui pass node.
-pub struct EguiPassNode {
-    egui_view_query: QueryState<(&'static ExtractedView, &'static EguiViewTarget)>,
-    egui_view_target_query: QueryState<(&'static ViewTarget, &'static ExtractedCamera)>,
-}
+pub fn prepare_egui_pass(world: &mut World) {
+    world.resource_scope(|world, mut render_data: Mut<EguiRenderData>| {
+        for (_main_entity, data) in &mut render_data.0 {
+            let Some(key) = data.key else {
+                bevy_log::warn!("Failed to retrieve egui node data!");
+                return;
+            };
 
-impl EguiPassNode {
-    /// Creates an Egui pass node.
-    pub fn new(world: &mut World) -> Self {
-        Self {
-            egui_view_query: world.query_filtered(),
-            egui_view_target_query: world.query(),
+            for (clip_rect, command) in data.postponed_updates.drain(..) {
+                let info = egui::PaintCallbackInfo {
+                    viewport: command.rect,
+                    clip_rect,
+                    pixels_per_point: data.pixels_per_point,
+                    screen_size_px: data.target_size.to_array(),
+                };
+                command
+                    .callback
+                    .cb()
+                    .update(info, data.render_entity, key, world);
+            }
         }
-    }
+    });
 }
 
-impl Node for EguiPassNode {
-    fn update(&mut self, world: &mut World) {
-        self.egui_view_query.update_archetypes(world);
-        self.egui_view_target_query.update_archetypes(world);
+pub fn egui_pass(
+    world: &World,
+    view: ViewQuery<&UiCameraView>,
+    ui_view_query: Query<(&ExtractedView, &UiViewTarget)>,
+    ui_view_target_query: Query<(&ViewTarget, &ExtractedCamera)>,
+    mut ctx: RenderContext,
+) {
+    let ui_camera_view = view.into_inner();
+    let ui_view_entity = ui_camera_view.0;
 
-        world.resource_scope(|world, mut render_data: Mut<EguiRenderData>| {
-            for (_main_entity, data) in &mut render_data.0 {
-                let Some(key) = data.key else {
-                    bevy_log::warn!("Failed to retrieve egui node data!");
-                    return;
+    let Ok((extracted_view, ui_view_target)) = ui_view_query.get(ui_view_entity) else {
+        return;
+    };
+
+    let Ok((target, camera)) = ui_view_target_query.get(ui_view_target.0) else {
+        return;
+    };
+
+    let egui_pipelines = world.resource::<EguiPipelines>();
+    let egui_pipelines = &egui_pipelines.0;
+    let pipeline_cache = world.resource::<PipelineCache>();
+    let render_data = world.resource::<EguiRenderData>();
+
+    let Some(data) = render_data
+        .0
+        .get(&extracted_view.retained_view_entity.main_entity)
+    else {
+        bevy_log::warn!("Failed to retrieve render data for egui node rendering!");
+        return;
+    };
+
+    let mut render_pass = ctx.begin_tracked_render_pass(RenderPassDescriptor {
+        label: Some("egui_pass"),
+        color_attachments: &[Some(target.get_unsampled_color_attachment())],
+        depth_stencil_attachment: None,
+        timestamp_writes: None,
+        occlusion_query_set: None,
+        multiview_mask: None,
+    });
+    let Some(viewport) = camera.viewport.clone().or_else(|| {
+        camera.physical_viewport_size.map(|size| Viewport {
+            physical_position: UVec2::ZERO,
+            physical_size: size,
+            ..Default::default()
+        })
+    }) else {
+        return;
+    };
+    render_pass.set_camera_viewport(&Viewport {
+        physical_position: UVec2::ZERO,
+        physical_size: camera.physical_target_size.unwrap(),
+        ..Default::default()
+    });
+
+    let mut requires_reset = true;
+    let mut last_scissor_rect = None;
+    let mut last_bindless_offset = None;
+
+    let pipeline_id = egui_pipelines
+        .get(&extracted_view.retained_view_entity.main_entity)
+        .expect("Expected a queued pipeline");
+    let Some(pipeline) = pipeline_cache.get_render_pipeline(*pipeline_id) else {
+        return;
+    };
+
+    let bind_groups = world.resource::<EguiTextureBindGroups>();
+    let egui_transforms = world.resource::<EguiTransforms>();
+    let transform_buffer_offset =
+        egui_transforms.offsets[&extracted_view.retained_view_entity.main_entity];
+    let transform_buffer_bind_group = &egui_transforms
+        .bind_group
+        .as_ref()
+        .expect("Expected a prepared bind group")
+        .1;
+
+    let (vertex_buffer, index_buffer) = match (&data.vertex_buffer, &data.index_buffer) {
+        (Some(vertex), Some(index)) => (vertex, index),
+        _ => {
+            return;
+        }
+    };
+
+    let mut vertex_offset: u32 = 0;
+    for draw_command in &data.draw_commands {
+        if requires_reset {
+            render_pass.set_render_pipeline(pipeline);
+            render_pass.set_bind_group(0, transform_buffer_bind_group, &[transform_buffer_offset]);
+            render_pass.set_camera_viewport(&Viewport {
+                physical_position: UVec2::ZERO,
+                physical_size: camera.physical_target_size.unwrap(),
+                ..Default::default()
+            });
+            requires_reset = false;
+
+            last_bindless_offset = None;
+            last_scissor_rect = None;
+        }
+
+        let clip_urect = URect {
+            min: UVec2 {
+                x: (draw_command.clip_rect.min.x * data.pixels_per_point).round() as u32,
+                y: (draw_command.clip_rect.min.y * data.pixels_per_point).round() as u32,
+            },
+            max: UVec2 {
+                x: (draw_command.clip_rect.max.x * data.pixels_per_point).round() as u32,
+                y: (draw_command.clip_rect.max.y * data.pixels_per_point).round() as u32,
+            },
+        };
+
+        let scissor_rect = clip_urect.intersect(URect {
+            min: viewport.physical_position,
+            max: viewport.physical_position + viewport.physical_size,
+        });
+        if scissor_rect.is_empty() {
+            continue;
+        }
+
+        if Some(scissor_rect) != last_scissor_rect {
+            last_scissor_rect = Some(scissor_rect);
+
+            // Bevy TrackedRenderPass doesn't track set_scissor_rect calls,
+            // so set_scissor_rect is updated only when it is needed.
+            render_pass.set_scissor_rect(
+                scissor_rect.min.x,
+                scissor_rect.min.y,
+                scissor_rect.width(),
+                scissor_rect.height(),
+            );
+        }
+
+        let Some(pipeline_key) = data.key else {
+            continue;
+        };
+        match &draw_command.primitive {
+            DrawPrimitive::Egui(command) => {
+                let Some((texture_bind_group, bindless_offset)) =
+                    bind_groups.get(&command.egui_texture)
+                else {
+                    vertex_offset += command.vertices_count as u32;
+                    continue;
                 };
 
-                for (clip_rect, command) in data.postponed_updates.drain(..) {
-                    let info = egui::PaintCallbackInfo {
-                        viewport: command.rect,
-                        clip_rect,
-                        pixels_per_point: data.pixels_per_point,
-                        screen_size_px: data.target_size.to_array(),
-                    };
-                    command
-                        .callback
-                        .cb()
-                        .update(info, data.render_entity, key, world);
+                render_pass.set_bind_group(1, texture_bind_group, &[]);
+                render_pass.set_vertex_buffer(0, vertex_buffer.slice(..));
+                render_pass.set_index_buffer(index_buffer.slice(..), IndexFormat::Uint32);
+
+                if let Some(bindless_offset) = bindless_offset
+                    && last_bindless_offset != Some(bindless_offset)
+                {
+                    last_bindless_offset = Some(bindless_offset);
+
+                    // Use immediates to cheaply provide which texture to use inside
+                    // binding array. This is used to avoid costly set_bind_group operations
+                    // when frequent switching between textures is being done
+                    render_pass.set_immediates(0, bytemuck::bytes_of(bindless_offset));
                 }
-            }
-        });
-    }
 
-    fn run<'w>(
-        &self,
-        graph: &mut RenderGraphContext,
-        render_context: &mut RenderContext<'w>,
-        world: &'w World,
-    ) -> Result<(), NodeRunError> {
-        let egui_pipelines = &world.resource::<EguiPipelines>().0;
-        let pipeline_cache = world.resource::<PipelineCache>();
-        let render_data = world.resource::<EguiRenderData>();
-
-        // Extract the UI view.
-        let input_view_entity = graph.view_entity();
-
-        // Query the UI view components.
-        let Ok((view, view_target)) = self.egui_view_query.get_manual(world, input_view_entity)
-        else {
-            return Ok(());
-        };
-
-        let Ok((target, camera)) = self.egui_view_target_query.get_manual(world, view_target.0)
-        else {
-            return Ok(());
-        };
-
-        let Some(data) = render_data.0.get(&view.retained_view_entity.main_entity) else {
-            bevy_log::warn!("Failed to retrieve render data for egui node rendering!");
-            return Ok(());
-        };
-
-        let mut render_pass = render_context.begin_tracked_render_pass(RenderPassDescriptor {
-            label: Some("egui_pass"),
-            color_attachments: &[Some(target.get_unsampled_color_attachment())],
-            depth_stencil_attachment: None,
-            timestamp_writes: None,
-            occlusion_query_set: None,
-        });
-        let Some(viewport) = camera.viewport.clone().or_else(|| {
-            camera.physical_viewport_size.map(|size| Viewport {
-                physical_position: UVec2::ZERO,
-                physical_size: size,
-                ..Default::default()
-            })
-        }) else {
-            return Ok(());
-        };
-        render_pass.set_camera_viewport(&Viewport {
-            physical_position: UVec2::ZERO,
-            physical_size: camera.physical_target_size.unwrap(),
-            ..Default::default()
-        });
-
-        let mut requires_reset = true;
-        let mut last_scissor_rect = None;
-        let mut last_bindless_offset = None;
-
-        let pipeline_id = egui_pipelines
-            .get(&view.retained_view_entity.main_entity)
-            .expect("Expected a queued pipeline");
-        let Some(pipeline) = pipeline_cache.get_render_pipeline(*pipeline_id) else {
-            return Ok(());
-        };
-
-        let bind_groups = world.resource::<EguiTextureBindGroups>();
-        let egui_transforms = world.resource::<EguiTransforms>();
-        let transform_buffer_offset =
-            egui_transforms.offsets[&view.retained_view_entity.main_entity];
-        let transform_buffer_bind_group = &egui_transforms
-            .bind_group
-            .as_ref()
-            .expect("Expected a prepared bind group")
-            .1;
-
-        let (vertex_buffer, index_buffer) = match (&data.vertex_buffer, &data.index_buffer) {
-            (Some(vertex), Some(index)) => (vertex, index),
-            _ => {
-                return Ok(());
-            }
-        };
-
-        let mut vertex_offset: u32 = 0;
-        for draw_command in &data.draw_commands {
-            if requires_reset {
-                render_pass.set_render_pipeline(pipeline);
-                render_pass.set_bind_group(
+                render_pass.draw_indexed(
+                    vertex_offset..(vertex_offset + command.vertices_count as u32),
                     0,
-                    transform_buffer_bind_group,
-                    &[transform_buffer_offset],
+                    0..1,
                 );
-                render_pass.set_camera_viewport(&Viewport {
-                    physical_position: UVec2::ZERO,
-                    physical_size: camera.physical_target_size.unwrap(),
-                    ..Default::default()
-                });
-                requires_reset = false;
 
-                last_bindless_offset = None;
-                last_scissor_rect = None;
+                vertex_offset += command.vertices_count as u32;
             }
+            DrawPrimitive::PaintCallback(command) => {
+                let info = egui::PaintCallbackInfo {
+                    viewport: command.rect,
+                    clip_rect: draw_command.clip_rect,
+                    pixels_per_point: data.pixels_per_point,
+                    screen_size_px: [viewport.physical_size.x, viewport.physical_size.y],
+                };
 
-            let clip_urect = URect {
-                min: UVec2 {
-                    x: (draw_command.clip_rect.min.x * data.pixels_per_point).round() as u32,
-                    y: (draw_command.clip_rect.min.y * data.pixels_per_point).round() as u32,
-                },
-                max: UVec2 {
-                    x: (draw_command.clip_rect.max.x * data.pixels_per_point).round() as u32,
-                    y: (draw_command.clip_rect.max.y * data.pixels_per_point).round() as u32,
-                },
-            };
-
-            let scissor_rect = clip_urect.intersect(URect {
-                min: viewport.physical_position,
-                max: viewport.physical_position + viewport.physical_size,
-            });
-            if scissor_rect.is_empty() {
-                continue;
-            }
-
-            if Some(scissor_rect) != last_scissor_rect {
-                last_scissor_rect = Some(scissor_rect);
-
-                // Bevy TrackedRenderPass doesn't track set_scissor_rect calls,
-                // so set_scissor_rect is updated only when it is needed.
-                render_pass.set_scissor_rect(
-                    scissor_rect.min.x,
-                    scissor_rect.min.y,
-                    scissor_rect.width(),
-                    scissor_rect.height(),
-                );
-            }
-
-            let Some(pipeline_key) = data.key else {
-                continue;
-            };
-            match &draw_command.primitive {
-                DrawPrimitive::Egui(command) => {
-                    let Some((texture_bind_group, bindless_offset)) =
-                        bind_groups.get(&command.egui_texture)
-                    else {
-                        vertex_offset += command.vertices_count as u32;
-                        continue;
-                    };
-
-                    render_pass.set_bind_group(1, texture_bind_group, &[]);
-                    render_pass.set_vertex_buffer(0, vertex_buffer.slice(..));
-                    render_pass.set_index_buffer(index_buffer.slice(..), IndexFormat::Uint32);
-
-                    if let Some(bindless_offset) = bindless_offset
-                        && last_bindless_offset != Some(bindless_offset)
-                    {
-                        last_bindless_offset = Some(bindless_offset);
-
-                        // Use immediates to cheaply provide which texture to use inside
-                        // binding array. This is used to avoid costly set_bind_group operations
-                        // when frequent switching between textures is being done
-                        render_pass.set_immediates(
-                            0,
-                            bytemuck::bytes_of(bindless_offset),
-                        );
-                    }
-
-                    render_pass.draw_indexed(
-                        vertex_offset..(vertex_offset + command.vertices_count as u32),
-                        0,
-                        0..1,
+                let viewport = info.viewport_in_pixels();
+                if viewport.width_px > 0 && viewport.height_px > 0 {
+                    requires_reset = true;
+                    render_pass.set_viewport(
+                        viewport.left_px as f32,
+                        viewport.top_px as f32,
+                        viewport.width_px as f32,
+                        viewport.height_px as f32,
+                        0.,
+                        1.,
                     );
 
-                    vertex_offset += command.vertices_count as u32;
-                }
-                DrawPrimitive::PaintCallback(command) => {
-                    let info = egui::PaintCallbackInfo {
-                        viewport: command.rect,
-                        clip_rect: draw_command.clip_rect,
-                        pixels_per_point: data.pixels_per_point,
-                        screen_size_px: [viewport.physical_size.x, viewport.physical_size.y],
-                    };
-
-                    let viewport = info.viewport_in_pixels();
-                    if viewport.width_px > 0 && viewport.height_px > 0 {
-                        requires_reset = true;
-                        render_pass.set_viewport(
-                            viewport.left_px as f32,
-                            viewport.top_px as f32,
-                            viewport.width_px as f32,
-                            viewport.height_px as f32,
-                            0.,
-                            1.,
-                        );
-
-                        command.callback.cb().render(
-                            info,
-                            &mut render_pass,
-                            RenderEntity::from(input_view_entity),
-                            pipeline_key,
-                            world,
-                        );
-                    }
+                    command.callback.cb().render(
+                        info,
+                        &mut render_pass,
+                        RenderEntity::from(ui_view_entity),
+                        pipeline_key,
+                        world,
+                    );
                 }
             }
         }
-
-        Ok(())
     }
 }

--- a/src/render/render_pass.rs
+++ b/src/render/render_pass.rs
@@ -10,12 +10,11 @@ use bevy_ecs::{
 use bevy_math::{URect, UVec2};
 use bevy_render::{
     camera::ExtractedCamera,
-    render_resource::{PipelineCache, RenderPassDescriptor},
+    render_resource::{IndexFormat, PipelineCache, RenderPassDescriptor},
     renderer::{RenderContext, ViewQuery},
     sync_world::RenderEntity,
     view::{ExtractedView, ViewTarget},
 };
-use wgpu_types::IndexFormat;
 
 /// Prepare egui render pass
 pub fn prepare_egui_pass(world: &mut World) {

--- a/src/render/render_pass.rs
+++ b/src/render/render_pass.rs
@@ -17,6 +17,7 @@ use bevy_render::{
 };
 use wgpu_types::IndexFormat;
 
+/// Prepare egui render pass
 pub fn prepare_egui_pass(world: &mut World) {
     world.resource_scope(|world, mut render_data: Mut<EguiRenderData>| {
         for (_main_entity, data) in &mut render_data.0 {
@@ -41,6 +42,7 @@ pub fn prepare_egui_pass(world: &mut World) {
     });
 }
 
+/// Egui render pass
 pub fn egui_pass(
     world: &World,
     view: ViewQuery<&EguiCameraView>,

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -29,6 +29,7 @@ use bevy_render::{
 };
 use bytemuck::cast_slice;
 use itertools::Itertools;
+use wgpu_types::TextureFormat;
 
 /// Extracted Egui settings.
 #[derive(Resource, Deref, DerefMut, Default)]
@@ -277,7 +278,11 @@ pub fn queue_pipelines_system(
                 &pipeline_cache,
                 &egui_pipeline,
                 EguiPipelineKey {
-                    hdr: extracted_camera.hdr,
+                    target_format: if extracted_camera.hdr {
+                        TextureFormat::Rgba16Float
+                    } else {
+                        TextureFormat::Rgba8UnormSrgb
+                    },
                 },
             );
             Some((*main_entity, pipeline_id))
@@ -365,7 +370,7 @@ pub fn prepare_egui_render_target_data_system(
             continue;
         };
         data.key = Some(EguiPipelineKey {
-            hdr: extracted_camera.hdr,
+            target_format: view.target_format,
         });
 
         data.pixels_per_point = computed_scale_factor.scale_factor;

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -18,8 +18,9 @@ use bevy_render::{
     extract_resource::ExtractResource,
     render_asset::RenderAssets,
     render_resource::{
-        BindGroup, BindGroupEntry, BindingResource, Buffer, BufferDescriptor, BufferId,
-        CachedRenderPipelineId, DynamicUniformBuffer, PipelineCache, SpecializedRenderPipelines,
+        BindGroup, BindGroupEntry, BindingResource, Buffer, BufferAddress, BufferDescriptor,
+        BufferId, BufferUsages, CachedRenderPipelineId, DynamicUniformBuffer, PipelineCache,
+        SpecializedRenderPipelines,
     },
     renderer::{RenderDevice, RenderQueue},
     sync_world::{MainEntity, RenderEntity},
@@ -28,7 +29,6 @@ use bevy_render::{
 };
 use bytemuck::cast_slice;
 use itertools::Itertools;
-use wgpu_types::{BufferAddress, BufferUsages};
 
 /// Extracted Egui settings.
 #[derive(Resource, Deref, DerefMut, Default)]


### PR DESCRIPTION
:warning: **This is still a WIP, I am still testing and fixing some stuff, I will be updating the broken and todo sections as I work on this.**

To use this branch, add this to your `Cargo.toml`: 

```toml
[dependencies]
bevy = "0.19.0-rc.2"
bevy_egui = { git = "https://github.com/taboky-dev/bevy_egui.git", rev = "ee645af" }
```

---

### Broken
- ~~The `accesskit` feature won't compile due to egui's `accesskit` dependency being outdated (https://github.com/emilk/egui/pull/7850)~~
- Some examples are not working as intended (see below)

### Todo
- [x] Add missing documentation
- [x] Fix ui render order
- [x] Update `wgpu-types` to 0.29 
- [x] Update `egui` to 0.34
- [x] `EguiAboveBevyUi` causes bevy ui to be un-pickable
- [x] Replace deprecated method `egui::Context::run` with `egui::Context::run_ui`
- [x] Fix broken examples
  - [x] `color_test` "Render to image (Mesh)" option is not rendering at all
  - [x] `paint_callback` panics
  - [x] `render_to_image_widget` does not compile
  - [x] `side_panel` prints warnings every frame

(Closes #473)