### PR TITLE
Cargo.toml: enable "wayland-data-control" feature for arboard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,8 @@ bevy_picking = { version = "0.18.0", optional = true, features = ["mesh_picking"
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
 arboard = { version = "3.2.0", optional = true }
 thread_local = { version = "1.1.0", optional = true }
+[target.'cfg(target_os = "linux")'.dependencies]
+arboard = { version = "3.2.0", optional = true, features = ["wayland-data-control"] }
 
 [dev-dependencies]
 version-sync = "0.9.5"


### PR DESCRIPTION
This enables copy-paste support under wayland.

Tested with Fedora KDE.