### PR TITLE
Update egui to `0.34`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_egui"
 version = "0.39.1"
-rust-version = "1.89.0"
+rust-version = "1.92.0"
 authors = ["vladbat00 <vladyslav.batyrenko@gmail.com>"]
 description = "A plugin for Egui integration into Bevy"
 license = "MIT"
@@ -14,30 +14,35 @@ features = ["bevy_winit/x11", "immutable_ctx"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-default = ["manage_clipboard", "open_url", "default_fonts", "render", "bevy_ui", "picking"]
-accesskit = ["egui/accesskit", "bevy_a11y"]
+default = [
+  "manage_clipboard",
+  "open_url",
+  "default_fonts",
+  "render",
+  "bevy_ui",
+  "picking",
+]
+accesskit = ["bevy_a11y"]
 immutable_ctx = []
 manage_clipboard = ["arboard", "thread_local", "bytemuck", "egui/bytemuck"]
 open_url = ["webbrowser"]
 default_fonts = ["egui/default_fonts"]
 render = [
-    "bevy_asset",
-    "bevy_core_pipeline",
-    "bevy_image",
-    "bevy_mesh",
-    "bevy_render",
-    "bevy_color",
-    "bevy_shader",
-    "bevy_transform",
-    "encase",
-    "bytemuck",
-    "egui/bytemuck",
-    "wgpu-types",
-    "itertools",
+  "bevy_asset",
+  "bevy_core_pipeline",
+  "bevy_image",
+  "bevy_mesh",
+  "bevy_render",
+  "bevy_color",
+  "bevy_shader",
+  "bevy_transform",
+  "encase",
+  "bytemuck",
+  "egui/bytemuck",
+  "wgpu-types",
+  "itertools",
 ]
-bevy_ui = [
-    "bevy_ui_render",
-]
+bevy_ui = ["bevy_ui_render"]
 picking = ["render", "bevy_picking"]
 serde = ["egui/serde"]
 # The enabled logs will print with the info log level, to make it less cumbersome to debug in browsers.
@@ -77,13 +82,18 @@ name = "ui"
 required-features = ["render"]
 [[example]]
 name = "render_egui_to_image"
-required-features = ["picking", "render", "bevy/bevy_gizmos", "bevy/bevy_gizmos_render"]
+required-features = [
+  "picking",
+  "render",
+  "bevy/bevy_gizmos",
+  "bevy/bevy_gizmos_render",
+]
 [[example]]
 name = "file_browse"
 required-features = ["render"]
 
 [dependencies]
-egui = { version = "0.33", default-features = false }
+egui = { version = "0.34", default-features = false }
 bevy_a11y = { version = "0.18.0", optional = true }
 bevy_app = { version = "0.18.0" }
 bevy_camera = { version = "0.18.0" }
@@ -122,7 +132,9 @@ wgpu-types = { version = "27.0", optional = true }
 bevy_ui_render = { version = "0.18.0", optional = true }
 
 # `picking` feature
-bevy_picking = { version = "0.18.0", optional = true, features = ["mesh_picking"] }
+bevy_picking = { version = "0.18.0", optional = true, features = [
+  "mesh_picking",
+] }
 
 # `manage_clipboard` feature
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
@@ -132,53 +144,57 @@ thread_local = { version = "1.1.0", optional = true }
 [dev-dependencies]
 version-sync = "0.9.5"
 bevy = { version = "0.18.0", default-features = false, features = [
-    "bevy_log",
-    "bevy_asset",
-    "bevy_core_pipeline",
-    "bevy_pbr",
-    "mesh_picking",
-    "bevy_sprite",
-    "bevy_sprite_render",
-    "bevy_text",
-    "bevy_window",
-    "bevy_winit",
-    "mouse",
-    "keyboard",
-    "touch",
-    "gestures",
-    "android-game-activity",
-    "png",
-    "std",
-    "tonemapping_luts",
-    "webgl2",
-    "x11",
-    "zstd_rust"
+  "bevy_log",
+  "bevy_asset",
+  "bevy_core_pipeline",
+  "bevy_pbr",
+  "mesh_picking",
+  "bevy_sprite",
+  "bevy_sprite_render",
+  "bevy_text",
+  "bevy_window",
+  "bevy_winit",
+  "mouse",
+  "keyboard",
+  "touch",
+  "gestures",
+  "android-game-activity",
+  "png",
+  "std",
+  "tonemapping_luts",
+  "webgl2",
+  "x11",
+  "zstd_rust",
 ] }
-egui = { version = "0.33", default-features = false, features = ["bytemuck"] }
+egui = { version = "0.34", default-features = false, features = ["bytemuck"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-bevy = { version = "0.18.0", default-features = false, features = ["accesskit_unix"] }
+bevy = { version = "0.18.0", default-features = false, features = [
+  "accesskit_unix",
+] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dev-dependencies]
 rfd = "0.17"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3.74", features = [
-    "Clipboard",
-    "ClipboardEvent",
-    "ClipboardItem",
-    "CompositionEvent",
-    "DataTransfer",
-    "Document",
-    "EventTarget",
-    "HtmlInputElement",
-    "InputEvent",
-    "KeyboardEvent",
-    "Navigator",
-    "TouchEvent",
-    "Window",
+  "Clipboard",
+  "ClipboardEvent",
+  "ClipboardItem",
+  "CompositionEvent",
+  "DataTransfer",
+  "Document",
+  "EventTarget",
+  "HtmlInputElement",
+  "InputEvent",
+  "KeyboardEvent",
+  "Navigator",
+  "TouchEvent",
+  "Window",
 ] }
-image = { version = "0.25.5", default-features = false, features = ["png"] } # For copying images
+image = { version = "0.25.5", default-features = false, features = [
+  "png",
+] } # For copying images
 js-sys = "0.3.63"
 wasm-bindgen = "0.2.93"
 wasm-bindgen-futures = "0.4.36"

--- a/src/input.rs
+++ b/src/input.rs
@@ -551,6 +551,7 @@ pub fn write_mouse_wheel_messages_system(
             event: egui::Event::MouseWheel {
                 unit,
                 delta,
+                phase: egui::TouchPhase::Move,
                 modifiers,
             },
         });
@@ -1329,14 +1330,15 @@ pub fn write_egui_wants_input_system(
     for mut ctx in egui_context_query.iter_mut() {
         let egui_ctx = ctx.get_mut();
         egui_wants_input.is_pointer_over_area =
-            egui_wants_input.is_pointer_over_area || egui_ctx.is_pointer_over_area();
+            egui_wants_input.is_pointer_over_area || egui_ctx.is_pointer_over_egui();
         egui_wants_input.wants_pointer_input =
-            egui_wants_input.wants_pointer_input || egui_ctx.wants_pointer_input();
+            egui_wants_input.wants_pointer_input || egui_ctx.egui_wants_pointer_input();
         egui_wants_input.is_using_pointer =
-            egui_wants_input.is_using_pointer || egui_ctx.is_using_pointer();
+            egui_wants_input.is_using_pointer || egui_ctx.egui_is_using_pointer();
         egui_wants_input.wants_keyboard_input =
-            egui_wants_input.wants_keyboard_input || egui_ctx.wants_keyboard_input();
-        egui_wants_input.is_popup_open = egui_wants_input.is_popup_open || egui_ctx.is_popup_open();
+            egui_wants_input.wants_keyboard_input || egui_ctx.egui_wants_keyboard_input();
+        egui_wants_input.is_popup_open =
+            egui_wants_input.is_popup_open || egui_ctx.any_popup_open();
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1638,7 +1638,7 @@ pub fn capture_pointer_input_system(
                     continue;
                 }
 
-                if settings.capture_pointer_input && ctx.get_mut().wants_pointer_input() {
+                if settings.capture_pointer_input && ctx.get_mut().egui_wants_pointer_input() {
                     let entry = (entity, HitData::new(entity, 0.0, None, None));
                     output.write(PointerHits::new(
                         *pointer,
@@ -1940,7 +1940,7 @@ pub fn run_egui_context_pass_loop_system(world: &mut World) {
             );
         }
 
-        let output = ctx.run(input.take(), |_| {
+        let output = ctx.run_ui(input.take(), |_| {
             let _ = world.try_run_schedule(*multipass_schedule);
         });
 


### PR DESCRIPTION
Updates egui to `0.34`, only small changes.

MSRV of egui was updated to 1.92, some functions deprecated (changed to equivalents) and accesskit feature no longer needed as egui always depends on it