### PR TITLE
clipboard: add smithay-clipboard for wayland support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ features = ["bevy_winit/x11", "immutable_ctx"]
 default = ["manage_clipboard", "open_url", "default_fonts", "render", "bevy_ui", "picking"]
 accesskit = ["egui/accesskit", "bevy_a11y"]
 immutable_ctx = []
-manage_clipboard = ["arboard", "thread_local", "bytemuck", "egui/bytemuck"]
+manage_clipboard = ["arboard", "thread_local", "bytemuck", "egui/bytemuck", "smithay-clipboard"]
 open_url = ["webbrowser"]
 default_fonts = ["egui/default_fonts"]
 render = [
@@ -128,6 +128,8 @@ bevy_picking = { version = "0.18.0", optional = true, features = ["mesh_picking"
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
 arboard = { version = "3.2.0", optional = true }
 thread_local = { version = "1.1.0", optional = true }
+[target.'cfg(any(target_os="linux", target_os="dragonfly", target_os="freebsd", target_os="netbsd", target_os="openbsd"))'.dependencies]
+smithay-clipboard = { version = "0.7.2", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1386,7 +1386,7 @@ impl Plugin for EguiPlugin {
             ),
             feature = "manage_clipboard"
         ))]
-        if let Some(display_handle_wrapper) = _app
+        if let Some(display_handle_wrapper) = app
             .world_mut()
             .get_resource::<bevy_winit::DisplayHandleWrapper>()
         {
@@ -1397,7 +1397,7 @@ impl Plugin for EguiPlugin {
                 .map(|h| h.as_raw());
             if let Some(RawDisplayHandle::Wayland(display)) = raw_display_handle {
                 log::debug!("Initializing smithay clipboard");
-                let mut egui_clipboard = _app.world_mut().resource_mut::<EguiClipboard>();
+                let mut egui_clipboard = app.world_mut().resource_mut::<EguiClipboard>();
                 // Safety: display is also stored as a resource and thus has the same lifetime
                 egui_clipboard.wayland_clipboard = Some(Arc::new(Mutex::new(unsafe {
                     smithay_clipboard::Clipboard::new(display.display.as_ptr())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,17 +206,6 @@ use std::cell::{RefCell, RefMut};
 use std::sync::{Arc, Mutex};
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
-#[cfg(all(
-    any(
-        target_os = "linux",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd"
-    ),
-    feature = "manage_clipboard"
-))]
-use winit::raw_window_handle::{HasDisplayHandle, RawDisplayHandle};
 
 /// Adds all Egui resources and render graph nodes.
 pub struct EguiPlugin {
@@ -1390,12 +1379,15 @@ impl Plugin for EguiPlugin {
             .world_mut()
             .get_resource::<bevy_winit::DisplayHandleWrapper>()
         {
+            use winit::raw_window_handle::HasDisplayHandle;
             let raw_display_handle = display_handle_wrapper
                 .0
                 .display_handle()
                 .ok()
                 .map(|h| h.as_raw());
-            if let Some(RawDisplayHandle::Wayland(display)) = raw_display_handle {
+            if let Some(winit::raw_window_handle::RawDisplayHandle::Wayland(display)) =
+                raw_display_handle
+            {
                 log::debug!("Initializing smithay clipboard");
                 let mut egui_clipboard = app.world_mut().resource_mut::<EguiClipboard>();
                 // Safety: display is also stored as a resource and thus has the same lifetime

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,11 +153,6 @@ use crate::text_agent::{
     is_mobile_safari, process_safari_virtual_keyboard_system,
     write_text_agent_channel_events_system,
 };
-#[cfg(all(
-    feature = "manage_clipboard",
-    not(any(target_arch = "wasm32", target_os = "android"))
-))]
-use arboard::Clipboard;
 use bevy_app::prelude::*;
 #[cfg(feature = "render")]
 use bevy_asset::{AssetEvent, AssetId, Assets, Handle, load_internal_asset};
@@ -198,8 +193,30 @@ use output::process_output_system;
     not(any(target_arch = "wasm32", target_os = "android"))
 ))]
 use std::cell::{RefCell, RefMut};
+#[cfg(all(
+    any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ),
+    feature = "manage_clipboard"
+))]
+use std::sync::{Arc, Mutex};
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
+#[cfg(all(
+    any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ),
+    feature = "manage_clipboard"
+))]
+use winit::raw_window_handle::{HasDisplayHandle, RawDisplayHandle};
 
 /// Adds all Egui resources and render graph nodes.
 pub struct EguiPlugin {
@@ -596,7 +613,18 @@ pub struct EguiFullOutput(pub Option<egui::FullOutput>);
 #[derive(Default, Resource)]
 pub struct EguiClipboard {
     #[cfg(not(target_arch = "wasm32"))]
-    clipboard: thread_local::ThreadLocal<Option<RefCell<Clipboard>>>,
+    clipboard: thread_local::ThreadLocal<Option<RefCell<arboard::Clipboard>>>,
+    #[cfg(all(
+        any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        ),
+        feature = "manage_clipboard"
+    ))]
+    wayland_clipboard: Option<Arc<Mutex<smithay_clipboard::Clipboard>>>,
     #[cfg(target_arch = "wasm32")]
     clipboard: web_clipboard::WebClipboard,
 }
@@ -1326,12 +1354,12 @@ impl Plugin for EguiPlugin {
         );
     }
 
-    #[cfg(feature = "render")]
-    fn finish(&self, app: &mut App) {
-        #[cfg(feature = "bevy_ui")]
-        let bevy_ui_is_enabled = app.is_plugin_added::<bevy_ui_render::UiRenderPlugin>();
+    fn finish(&self, _app: &mut App) {
+        #[cfg(all(feature = "bevy_ui", feature = "render"))]
+        let bevy_ui_is_enabled = _app.is_plugin_added::<bevy_ui_render::UiRenderPlugin>();
 
-        if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
+        #[cfg(feature = "render")]
+        if let Some(render_app) = _app.get_sub_app_mut(RenderApp) {
             render_app
                 .insert_resource(render::EguiRenderSettings {
                     bindless_mode_array_size: self.bindless_mode_array_size,
@@ -1416,6 +1444,36 @@ impl Plugin for EguiPlugin {
                 log::debug!(
                     "bevy_ui feature is enabled, but bevy_ui::UiPlugin is disabled, not applying configured rendering order"
                 )
+            }
+        }
+
+        // Init smithay-clipboard: it needs a wayland display handle
+        #[cfg(all(
+            any(
+                target_os = "linux",
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            ),
+            feature = "manage_clipboard"
+        ))]
+        if let Some(display_handle_wrapper) = _app
+            .world_mut()
+            .get_resource::<bevy_winit::DisplayHandleWrapper>()
+        {
+            let raw_display_handle = display_handle_wrapper
+                .0
+                .display_handle()
+                .ok()
+                .map(|h| h.as_raw());
+            if let Some(RawDisplayHandle::Wayland(display)) = raw_display_handle {
+                log::debug!("Initializing smithay clipboard");
+                let mut egui_clipboard = _app.world_mut().resource_mut::<EguiClipboard>();
+                // Safety: display is also stored as a resource and thus has the same lifetime
+                egui_clipboard.wayland_clipboard = Some(Arc::new(Mutex::new(unsafe {
+                    smithay_clipboard::Clipboard::new(display.display.as_ptr())
+                })));
             }
         }
     }
@@ -1524,6 +1582,23 @@ impl EguiClipboard {
 
     #[cfg(not(target_arch = "wasm32"))]
     fn set_text_impl(&mut self, contents: &str) {
+        // Try wayland first
+        #[cfg(all(
+            any(
+                target_os = "linux",
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            ),
+            feature = "manage_clipboard"
+        ))]
+        if let Some(wayland_clipboard) = &self.wayland_clipboard {
+            let wayland_clipboard = wayland_clipboard.lock().unwrap();
+            wayland_clipboard.store(contents);
+            return;
+        }
+
         if let Some(mut clipboard) = self.get()
             && let Err(err) = clipboard.set_text(contents.to_owned())
         {
@@ -1538,6 +1613,28 @@ impl EguiClipboard {
 
     #[cfg(not(target_arch = "wasm32"))]
     fn get_text_impl(&mut self) -> Option<String> {
+        // Try wayland first
+        #[cfg(all(
+            any(
+                target_os = "linux",
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            ),
+            feature = "manage_clipboard"
+        ))]
+        if let Some(wayland_clipboard) = &self.wayland_clipboard {
+            let wayland_clipboard = wayland_clipboard.lock().unwrap();
+            return match wayland_clipboard.load() {
+                Ok(text) => Some(text),
+                Err(err) => {
+                    log::error!("Failed to get clipboard content via smithay: {err}");
+                    None
+                }
+            };
+        }
+
         if let Some(mut clipboard) = self.get() {
             match clipboard.get_text() {
                 Ok(contents) => return Some(contents),
@@ -1557,6 +1654,22 @@ impl EguiClipboard {
 
     #[cfg(not(target_arch = "wasm32"))]
     fn set_image_impl(&mut self, image: &egui::ColorImage) {
+        // Try wayland first
+        #[cfg(all(
+            any(
+                target_os = "linux",
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            ),
+            feature = "manage_clipboard"
+        ))]
+        if self.wayland_clipboard.is_some() {
+            log::error!("Setting image to clipboard via smithay is not supported");
+            return;
+        }
+
         if let Some(mut clipboard) = self.get()
             && let Err(err) = clipboard.set_image(arboard::ImageData {
                 width: image.width(),
@@ -1574,13 +1687,13 @@ impl EguiClipboard {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    fn get(&self) -> Option<RefMut<'_, Clipboard>> {
+    fn get(&self) -> Option<RefMut<'_, arboard::Clipboard>> {
         self.clipboard
             .get_or(|| {
-                Clipboard::new()
+                arboard::Clipboard::new()
                     .map(RefCell::new)
                     .map_err(|err| {
-                        log::error!("Failed to initialize clipboard: {:?}", err);
+                        log::error!("Failed to initialize arboard clipboard: {:?}", err);
                     })
                     .ok()
             })


### PR DESCRIPTION
As discussed in https://github.com/vladbat00/bevy_egui/pull/476.
This follows the implementation of winit.

Tested under Linux with and without 'wayland' feature.

The need to pass a window handle required a bit of a different initialization strategy.
And I'm not sure if there is a way or guarantee in bevy for the destruction order of resources: strictly speaking the Display needs to be destroyed after the smithay clipboard instance.