### PR TITLE
Schedule 3D egui pass after TAA

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1307,7 +1307,7 @@ impl Plugin for EguiPlugin {
                 .after(bevy_core_pipeline::Core2dSystems::MainPass)
                 .before(bevy_core_pipeline::upscaling::upscaling);
             let egui_pass_3d = render::egui_pass
-                .after(bevy_core_pipeline::Core3dSystems::MainPass)
+                .after(bevy_core_pipeline::Core3dSystems::EarlyPostProcess)
                 .before(bevy_core_pipeline::upscaling::upscaling);
 
             #[cfg(feature = "bevy_ui")]


### PR DESCRIPTION
Fixes #483.

The 3D egui render pass was scheduled after `Core3dSystems::MainPass`, which means it could run before Bevy's early post-process systems such as TAA. When TAA is enabled, egui output could then be accumulated into the frame history, causing UI windows to smear or trail.

This schedules the 3D egui pass after `Core3dSystems::EarlyPostProcess` while still keeping it before upscaling, so egui renders after TAA and remains crisp.