### PR TITLE
Derive `Default` for `PrimaryEguiContext`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -535,7 +535,7 @@ impl Default for EguiInputSystemSettings {
 pub struct EguiPrimaryContextPass;
 
 /// A marker component for a primary Egui context.
-#[derive(Component, Clone)]
+#[derive(Component, Clone, Default)]
 #[require(EguiContext)]
 #[component(on_insert = insert_schedule_if_multipass)]
 pub struct PrimaryEguiContext;


### PR DESCRIPTION
The `PrimaryEguiContext` component currently cannot be used in BSN since it does not implement `FromTemplate`. Since `FromTemplate` is blanket implemented for all `Clone + Default` types, implementing `Default` for `PrimaryEguiContext` will enable its use in BSN.