### PR TITLE
update to egui 0.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.40.1] - Unreleased
+
+### Changed
+- Update to egui 0.35
+
+
 ## [0.40.1] - 24-Jun-2026
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ bevy_color = { version = "0.19", optional = true }
 bevy_shader = { version = "0.19", optional = true }
 bevy_transform = { version = "0.19", optional = true }
 encase = { version = "0.12", optional = true }
-itertools = { version = "0.15", optional = true }
+itertools = { version = "0.14", optional = true }
 wgpu-types = { version = "29.0.3", optional = true }
 
 # `bevy_ui` feature

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,21 +84,21 @@ name = "file_browse"
 required-features = ["render"]
 
 [dependencies]
-egui = { version = "0.34", default-features = false }
-bevy_a11y = { version = "0.19.0", optional = true }
-bevy_app = { version = "0.19.0" }
-bevy_camera = { version = "0.19.0" }
-bevy_derive = { version = "0.19.0" }
-bevy_ecs = { version = "0.19.0" }
-bevy_input = { version = "0.19.0" }
-bevy_log = { version = "0.19.0" }
-bevy_math = { version = "0.19.0" }
-bevy_platform = { version = "0.19.0" }
-bevy_reflect = { version = "0.19.0" }
-bevy_time = { version = "0.19.0" }
-bevy_window = { version = "0.19.0" }
-bevy_winit = { version = "0.19.0" }
-bevy_utils = { version = "0.19.0", features = ["debug"] }
+egui = { version = "0.35", default-features = false }
+bevy_a11y = { version = "0.19", optional = true }
+bevy_app = { version = "0.19" }
+bevy_camera = { version = "0.19" }
+bevy_derive = { version = "0.19" }
+bevy_ecs = { version = "0.19" }
+bevy_input = { version = "0.19" }
+bevy_log = { version = "0.19" }
+bevy_math = { version = "0.19" }
+bevy_platform = { version = "0.19" }
+bevy_reflect = { version = "0.19" }
+bevy_time = { version = "0.19" }
+bevy_window = { version = "0.19" }
+bevy_winit = { version = "0.19" }
+bevy_utils = { version = "0.19", features = ["debug"] }
 winit = { version = "0.30", default-features = false }
 
 # `open_url` feature
@@ -107,23 +107,23 @@ webbrowser = { version = "1.0.1", optional = true }
 # `render` feature
 bytemuck = { version = "1", optional = true }
 
-bevy_asset = { version = "0.19.0", optional = true }
-bevy_core_pipeline = { version = "0.19.0", optional = true }
-bevy_image = { version = "0.19.0", features = ["zstd_rust"], optional = true }
-bevy_mesh = { version = "0.19.0", optional = true }
-bevy_render = { version = "0.19.0", optional = true }
-bevy_color = { version = "0.19.0", optional = true }
-bevy_shader = { version = "0.19.0", optional = true }
-bevy_transform = { version = "0.19.0", optional = true }
+bevy_asset = { version = "0.19", optional = true }
+bevy_core_pipeline = { version = "0.19", optional = true }
+bevy_image = { version = "0.19", features = ["zstd_rust"], optional = true }
+bevy_mesh = { version = "0.19", optional = true }
+bevy_render = { version = "0.19", optional = true }
+bevy_color = { version = "0.19", optional = true }
+bevy_shader = { version = "0.19", optional = true }
+bevy_transform = { version = "0.19", optional = true }
 encase = { version = "0.12", optional = true }
-itertools = { version = "0.14", optional = true }
+itertools = { version = "0.15", optional = true }
 wgpu-types = { version = "29.0.3", optional = true }
 
 # `bevy_ui` feature
-bevy_ui_render = { version = "0.19.0", optional = true }
+bevy_ui_render = { version = "0.19", optional = true }
 
 # `picking` feature
-bevy_picking = { version = "0.19.0", optional = true, features = ["mesh_picking"] }
+bevy_picking = { version = "0.19", optional = true, features = ["mesh_picking"] }
 
 # `manage_clipboard` feature
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
@@ -134,7 +134,7 @@ smithay-clipboard = { version = "0.7.2", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9.5"
-bevy = { version = "0.19.0", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
     "bevy_log",
     "bevy_asset",
     "bevy_core_pipeline",
@@ -159,10 +159,10 @@ bevy = { version = "0.19.0", default-features = false, features = [
     "x11",
     "zstd_rust"
 ] }
-egui = { version = "0.34", default-features = false, features = ["bytemuck"] }
+egui = { version = "0.35", default-features = false, features = ["bytemuck"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-bevy = { version = "0.19.0", default-features = false, features = ["accesskit_unix"] }
+bevy = { version = "0.19", default-features = false, features = ["accesskit_unix"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))'.dev-dependencies]
 rfd = "0.17"

--- a/examples/color_test.rs
+++ b/examples/color_test.rs
@@ -235,7 +235,7 @@ fn ui_system(
     );
 
     app_state.top_panel_height = egui::Panel::top("top_panel")
-        .show_inside(&mut viewport_ui, |ui| {
+        .show(&mut viewport_ui, |ui| {
             ui.horizontal(|ui| {
                 ui.selectable_value(
                     &mut app_state.displayed_ui,
@@ -260,7 +260,7 @@ fn ui_system(
 
     match app_state.displayed_ui {
         DisplayedUi::Regular => {
-            egui::CentralPanel::default().show_inside(&mut viewport_ui, |ui| {
+            egui::CentralPanel::default().show(&mut viewport_ui, |ui| {
                 egui::ScrollArea::vertical().show(ui, |ui| {
                     app_state.color_test.ui(ui);
                 });
@@ -273,7 +273,7 @@ fn ui_system(
                 .expect("Expected a created image");
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show_inside(&mut viewport_ui, |ui| {
+                .show(&mut viewport_ui, |ui| {
                     ui.image(egui::load::SizedTexture::new(
                         app_state.egui_texture_image_id,
                         [
@@ -300,7 +300,7 @@ fn render_to_image_ui_system<C: Component>(
             .layer_id(LayerId::background())
             .max_rect(ctx.viewport_rect()),
     );
-    egui::CentralPanel::default().show_inside(&mut viewport_ui, |ui| {
+    egui::CentralPanel::default().show(&mut viewport_ui, |ui| {
         egui::ScrollArea::vertical().show(ui, |ui| {
             app_state.color_test.ui(ui);
         });

--- a/examples/file_browse.rs
+++ b/examples/file_browse.rs
@@ -45,7 +45,7 @@ mod foo {
                 .layer_id(LayerId::background())
                 .max_rect(ctx.viewport_rect()),
         );
-        egui::CentralPanel::default().show_inside(&mut viewport_ui, |ui| {
+        egui::CentralPanel::default().show(&mut viewport_ui, |ui| {
             ui.label("Drag-and-drop files onto the window!");
 
             if let Some(file_response) = file_dialog

--- a/examples/side_panel.rs
+++ b/examples/side_panel.rs
@@ -39,7 +39,7 @@ fn ui_example_system(
 
     let mut left = egui::Panel::left("left_panel")
         .resizable(true)
-        .show_inside(&mut viewport_ui, |ui| {
+        .show(&mut viewport_ui, |ui| {
             ui.label("Left resizeable panel");
             ui.allocate_rect(ui.available_rect_before_wrap(), egui::Sense::hover());
         })
@@ -49,7 +49,7 @@ fn ui_example_system(
 
     let mut right = egui::Panel::right("right_panel")
         .resizable(true)
-        .show_inside(&mut viewport_ui, |ui| {
+        .show(&mut viewport_ui, |ui| {
             ui.label("Right resizeable panel");
             ui.allocate_rect(ui.available_rect_before_wrap(), egui::Sense::hover());
         })
@@ -59,7 +59,7 @@ fn ui_example_system(
 
     let mut top = egui::Panel::top("top_panel")
         .resizable(true)
-        .show_inside(&mut viewport_ui, |ui| {
+        .show(&mut viewport_ui, |ui| {
             ui.label("Top resizeable panel");
             ui.allocate_rect(ui.available_rect_before_wrap(), egui::Sense::hover());
         })
@@ -68,7 +68,7 @@ fn ui_example_system(
         .height(); // width is ignored, as the panel has a width of 100% of the screen
     let mut bottom = egui::Panel::bottom("bottom_panel")
         .resizable(true)
-        .show_inside(&mut viewport_ui, |ui| {
+        .show(&mut viewport_ui, |ui| {
             ui.label("Bottom resizeable panel");
             ui.allocate_rect(ui.available_rect_before_wrap(), egui::Sense::hover());
         })

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -182,7 +182,7 @@ fn ui_example_system(
 
     egui::Panel::left("side_panel")
         .default_size(200.0)
-        .show_inside(&mut viewport_ui, |ui| {
+        .show(&mut viewport_ui, |ui| {
             ui.heading("Side Panel");
 
             ui.horizontal(|ui| {
@@ -224,7 +224,7 @@ fn ui_example_system(
             });
         });
 
-    egui::Panel::top("top_panel").show_inside(&mut viewport_ui, |ui| {
+    egui::Panel::top("top_panel").show(&mut viewport_ui, |ui| {
         // The top panel is often a good place for a menu bar:
         egui::MenuBar::new().ui(ui, |ui| {
             egui::containers::menu::MenuButton::new("File").ui(ui, |ui| {
@@ -235,7 +235,7 @@ fn ui_example_system(
         });
     });
 
-    egui::CentralPanel::default().show_inside(&mut viewport_ui, |ui| {
+    egui::CentralPanel::default().show(&mut viewport_ui, |ui| {
         ui.heading("Egui Template");
         ui.hyperlink("https://github.com/emilk/egui_template");
         ui.add(egui::github_link_file_line!(

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,8 +1,8 @@
 #[cfg(target_arch = "wasm32")]
 use crate::text_agent::{is_mobile_safari, update_text_agent};
 use crate::{
-    helpers::{vec2_into_egui_pos2, QueryHelper}, EguiContext, EguiContextSettings, EguiGlobalSettings, EguiInput, EguiOutput,
-    EguiZoomFactor,
+    EguiContext, EguiContextSettings, EguiGlobalSettings, EguiInput, EguiOutput, EguiZoomFactor,
+    helpers::{QueryHelper, vec2_into_egui_pos2},
 };
 use bevy_camera::Camera;
 use bevy_ecs::{
@@ -11,11 +11,11 @@ use bevy_ecs::{
     system::{NonSendMarker, SystemParam},
 };
 use bevy_input::{
-    gestures::PinchGesture, keyboard::{Key, KeyCode, KeyboardFocusLost, KeyboardInput},
+    ButtonInput, ButtonState,
+    gestures::PinchGesture,
+    keyboard::{Key, KeyCode, KeyboardFocusLost, KeyboardInput},
     mouse::{MouseButton, MouseButtonInput, MouseScrollUnit, MouseWheel},
     touch::TouchInput,
-    ButtonInput,
-    ButtonState,
 };
 use bevy_log::{self as log};
 use bevy_time::{Real, Time};

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,8 +1,8 @@
 #[cfg(target_arch = "wasm32")]
 use crate::text_agent::{is_mobile_safari, update_text_agent};
 use crate::{
-    EguiContext, EguiContextSettings, EguiGlobalSettings, EguiInput, EguiOutput, EguiZoomFactor,
-    helpers::{QueryHelper, vec2_into_egui_pos2},
+    helpers::{vec2_into_egui_pos2, QueryHelper}, EguiContext, EguiContextSettings, EguiGlobalSettings, EguiInput, EguiOutput,
+    EguiZoomFactor,
 };
 use bevy_camera::Camera;
 use bevy_ecs::{
@@ -11,11 +11,11 @@ use bevy_ecs::{
     system::{NonSendMarker, SystemParam},
 };
 use bevy_input::{
-    ButtonInput, ButtonState,
-    gestures::PinchGesture,
-    keyboard::{Key, KeyCode, KeyboardFocusLost, KeyboardInput},
+    gestures::PinchGesture, keyboard::{Key, KeyCode, KeyboardFocusLost, KeyboardInput},
     mouse::{MouseButton, MouseButtonInput, MouseScrollUnit, MouseWheel},
     touch::TouchInput,
+    ButtonInput,
+    ButtonState,
 };
 use bevy_log::{self as log};
 use bevy_time::{Real, Time};
@@ -40,8 +40,6 @@ pub struct EguiContextPointerTouchId {
 /// Stores per-context [IME](https://en.wikipedia.org/wiki/Input_method) state used by input and window integration.
 #[derive(Component, Default)]
 pub struct EguiContextImeState {
-    /// Indicates whether an IME composition is currently active for this context.
-    pub has_sent_ime_enabled: bool,
     /// Indicates whether IME is currently allowed, i.e. if the virtual keyboard is shown.
     pub is_ime_allowed: bool,
     /// Corresponds to where an active egui text edit is located on the screen.
@@ -731,7 +729,7 @@ pub fn write_ime_messages_system(
         | Ime::Disabled { window }
         | Ime::Enabled { window } => *window,
     }) {
-        let Some((_entity, context_settings, mut ime_state, _egui_output)) =
+        let Some((_entity, context_settings, _ime_state, _egui_output)) =
             egui_contexts.get_some_mut(context)
         else {
             continue;
@@ -745,21 +743,16 @@ pub fn write_ime_messages_system(
             continue;
         }
 
-        // Aligned with the egui-winit implementation: https://github.com/emilk/egui/blob/0f2b427ff4c0a8c68f6622ec7d0afb7ba7e71bba/crates/egui-winit/src/lib.rs#L348
+        // Aligned with the egui-winit implementation: https://github.com/emilk/egui/blob/68b74530b7848cef6bff4efc5fc9906bfbd1e8ca/crates/egui-winit/src/lib.rs#L697
         match message {
             Ime::Enabled { window: _ } => {
-                if cfg!(target_os = "linux") {
-                    // This event means different things in X11 and Wayland, but we can just
-                    // ignore it and enable IME on the preedit event.
-                    // See <https://github.com/rust-windowing/winit/issues/2498>
-                }
+                // NO-OP
             }
             Ime::Preedit {
                 value,
                 window: _,
                 cursor,
             } => {
-                ime_state.has_sent_ime_enabled = !value.is_empty();
                 egui_input_message_writer.write(EguiInputEvent {
                     context,
                     event: egui::Event::Ime(egui::ImeEvent::Preedit {
@@ -769,14 +762,13 @@ pub fn write_ime_messages_system(
                 });
             }
             Ime::Commit { value, window: _ } => {
-                ime_state.has_sent_ime_enabled = false;
                 egui_input_message_writer.write(EguiInputEvent {
                     context,
                     event: egui::Event::Ime(egui::ImeEvent::Commit(value.clone())),
                 });
             }
             Ime::Disabled { window: _ } => {
-                ime_state.has_sent_ime_enabled = false;
+                // NO-OP
             }
         }
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -37,10 +37,10 @@ pub struct EguiContextPointerTouchId {
     pub pointer_touch_id: Option<u64>,
 }
 
-/// Indicates whether [IME](https://en.wikipedia.org/wiki/Input_method) is enabled or disabled to avoid sending message duplicates.
+/// Stores per-context [IME](https://en.wikipedia.org/wiki/Input_method) state used by input and window integration.
 #[derive(Component, Default)]
 pub struct EguiContextImeState {
-    /// Indicates whether IME is enabled.
+    /// Indicates whether an IME composition is currently active for this context.
     pub has_sent_ime_enabled: bool,
     /// Indicates whether IME is currently allowed, i.e. if the virtual keyboard is shown.
     pub is_ime_allowed: bool,
@@ -745,30 +745,6 @@ pub fn write_ime_messages_system(
             continue;
         }
 
-        let ime_message_enable =
-            |ime_state: &mut EguiContextImeState,
-             egui_input_message_writer: &mut MessageWriter<EguiInputEvent>| {
-                if !ime_state.has_sent_ime_enabled {
-                    egui_input_message_writer.write(EguiInputEvent {
-                        context,
-                        event: egui::Event::Ime(egui::ImeEvent::Enabled),
-                    });
-                    ime_state.has_sent_ime_enabled = true;
-                }
-            };
-
-        let ime_message_disable =
-            |ime_state: &mut EguiContextImeState,
-             egui_input_message_writer: &mut MessageWriter<EguiInputEvent>| {
-                if !ime_state.has_sent_ime_enabled {
-                    egui_input_message_writer.write(EguiInputEvent {
-                        context,
-                        event: egui::Event::Ime(egui::ImeEvent::Disabled),
-                    });
-                    ime_state.has_sent_ime_enabled = false;
-                }
-            };
-
         // Aligned with the egui-winit implementation: https://github.com/emilk/egui/blob/0f2b427ff4c0a8c68f6622ec7d0afb7ba7e71bba/crates/egui-winit/src/lib.rs#L348
         match message {
             Ime::Enabled { window: _ } => {
@@ -776,35 +752,31 @@ pub fn write_ime_messages_system(
                     // This event means different things in X11 and Wayland, but we can just
                     // ignore it and enable IME on the preedit event.
                     // See <https://github.com/rust-windowing/winit/issues/2498>
-                } else {
-                    ime_message_enable(&mut ime_state, &mut egui_input_message_writer);
                 }
             }
             Ime::Preedit {
                 value,
                 window: _,
-                cursor: Some(_),
+                cursor,
             } => {
-                ime_message_enable(&mut ime_state, &mut egui_input_message_writer);
+                ime_state.has_sent_ime_enabled = !value.is_empty();
                 egui_input_message_writer.write(EguiInputEvent {
                     context,
-                    event: egui::Event::Ime(egui::ImeEvent::Preedit(value.clone())),
+                    event: egui::Event::Ime(egui::ImeEvent::Preedit {
+                        text: value.clone(),
+                        active_range_chars: cursor.map(|(start, end)| start..end),
+                    }),
                 });
             }
             Ime::Commit { value, window: _ } => {
+                ime_state.has_sent_ime_enabled = false;
                 egui_input_message_writer.write(EguiInputEvent {
                     context,
                     event: egui::Event::Ime(egui::ImeEvent::Commit(value.clone())),
                 });
-                ime_message_disable(&mut ime_state, &mut egui_input_message_writer);
             }
-            Ime::Disabled { window: _ }
-            | Ime::Preedit {
-                cursor: None,
-                window: _,
-                value: _,
-            } => {
-                ime_message_disable(&mut ime_state, &mut egui_input_message_writer);
+            Ime::Disabled { window: _ } => {
+                ime_state.has_sent_ime_enabled = false;
             }
         }
     }
@@ -1355,7 +1327,7 @@ impl EguiWantsInput {
     }
 
     /// Returns `true` if any of the following is true:
-    /// [`EguiWantsInput::is_pointer_over_area`], [`EguiWantsInput::wants_pointer_input`], [`EguiWantsInput::is_using_pointer`], [`EguiWantsInput::is_context_menu_open`].
+    /// [`EguiWantsInput::is_pointer_over_area`], [`EguiWantsInput::wants_pointer_input`], [`EguiWantsInput::is_using_pointer`], [`EguiWantsInput::is_popup_open`].
     pub fn wants_any_pointer_input(&self) -> bool {
         self.is_pointer_over_area
             || self.wants_pointer_input
@@ -1364,7 +1336,7 @@ impl EguiWantsInput {
     }
 
     /// Returns `true` if any of the following is true:
-    /// [`EguiWantsInput::wants_keyboard_input`], [`EguiWantsInput::is_context_menu_open`].
+    /// [`EguiWantsInput::wants_keyboard_input`], [`EguiWantsInput::is_popup_open`].
     pub fn wants_any_keyboard_input(&self) -> bool {
         self.wants_keyboard_input || self.is_popup_open
     }
@@ -1407,13 +1379,13 @@ pub fn write_egui_wants_input_system(
 }
 
 /// Returns `true` if any of the following is true:
-/// [`EguiWantsInput::is_pointer_over_area`], [`EguiWantsInput::wants_pointer_input`], [`EguiWantsInput::is_using_pointer`], [`EguiWantsInput::is_context_menu_open`].
+/// [`EguiWantsInput::is_pointer_over_area`], [`EguiWantsInput::wants_pointer_input`], [`EguiWantsInput::is_using_pointer`], [`EguiWantsInput::is_popup_open`].
 pub fn egui_wants_any_pointer_input(egui_wants_input_resource: Res<EguiWantsInput>) -> bool {
     egui_wants_input_resource.wants_any_pointer_input()
 }
 
 /// Returns `true` if any of the following is true:
-/// [`EguiWantsInput::wants_keyboard_input`], [`EguiWantsInput::is_context_menu_open`].
+/// [`EguiWantsInput::wants_keyboard_input`], [`EguiWantsInput::is_popup_open`].
 pub fn egui_wants_any_keyboard_input(egui_wants_input_resource: Res<EguiWantsInput>) -> bool {
     egui_wants_input_resource.wants_any_keyboard_input()
 }

--- a/src/text_agent.rs
+++ b/src/text_agent.rs
@@ -216,7 +216,6 @@ pub fn install_text_agent_system(
         });
 
         let input_clone = input.clone();
-        let sender_clone = sender.clone();
         let closure = Closure::wrap(Box::new(move |_event: web_sys::CompositionEvent| {
             #[cfg(feature = "log_input_messages")]
             log::warn!("Composition start: data={:?}", _event.data());

--- a/src/text_agent.rs
+++ b/src/text_agent.rs
@@ -221,7 +221,6 @@ pub fn install_text_agent_system(
             #[cfg(feature = "log_input_messages")]
             log::warn!("Composition start: data={:?}", _event.data());
             input_clone.set_value("");
-            let _ = sender_clone.send(egui::Event::Ime(egui::ImeEvent::Enabled));
         }) as Box<dyn FnMut(_)>);
         input
             .add_event_listener_with_callback("compositionstart", closure.as_ref().unchecked_ref())
@@ -242,7 +241,10 @@ pub fn install_text_agent_system(
             #[cfg(feature = "log_input_messages")]
             log::warn!("Composition update: data={:?}", event.data());
             let Some(text) = event.data() else { return };
-            let event = egui::Event::Ime(egui::ImeEvent::Preedit(text));
+            let event = egui::Event::Ime(egui::ImeEvent::Preedit {
+                text,
+                active_range_chars: None,
+            });
             let _ = sender_clone.send(event);
         }) as Box<dyn FnMut(_)>);
         input


### PR DESCRIPTION
`egui 0.35`  no longer uses ImeEvent::Enabled/Disabled (deprecated), and Ime::Preedit is now translated to egui::ImeEvent::Preedit { text, active_range_chars } with the Bevy cursor range mapped through.

I also changed `bevy 0.19.0` to `bevy 0.19`.
I fixed the following deprecations:
- `panel.show_inside(...)` -> `panel.show(...)`
- `EguiWantsInput::is_context_menu_open` -> `EguiWantsInput::is_popup_open`