### PR TITLE
fix: schedule egui 3d render pass after PostProcess to prevent tonemapping race

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1307,7 +1307,7 @@ impl Plugin for EguiPlugin {
                 .after(bevy_core_pipeline::Core2dSystems::MainPass)
                 .before(bevy_core_pipeline::upscaling::upscaling);
             let egui_pass_3d = render::egui_pass
-                .after(bevy_core_pipeline::Core3dSystems::EarlyPostProcess)
+                .after(bevy_core_pipeline::Core3dSystems::PostProcess)
                 .before(bevy_core_pipeline::upscaling::upscaling);
 
             #[cfg(feature = "bevy_ui")]


### PR DESCRIPTION
Closes #490 

Tested also 2d with HDR+tonymcmapface, flickering did not affect 2d pipeline, left it .after(MainPass)
